### PR TITLE
SteamVR_Camera logo width fit to inspector view

### DIFF
--- a/v54/Assets/SteamVR/Editor/SteamVR_Editor.cs
+++ b/v54/Assets/SteamVR/Editor/SteamVR_Editor.cs
@@ -42,7 +42,7 @@ public class SteamVR_Editor : Editor
 	{
 		serializedObject.Update();
 
-		var rect = GUILayoutUtility.GetRect(Screen.width - 38, bannerHeight, GUI.skin.box);
+		var rect = GUILayoutUtility.GetRect(EditorGUIUtility.currentViewWidth - 38, bannerHeight, GUI.skin.box);
 		if (logo)
 			GUI.DrawTexture(rect, logo, ScaleMode.ScaleToFit);
 


### PR DESCRIPTION
Prevent horizontal scrolling of 'Inspector' window content when `SteamVR_Camera` component is added to the camera game object.
Use `EditorGUIUtility.currentViewWidth` rather than `Screen.width` to calculate logo width.

Note only updating:

    v54/Assets/SteamVR/Editor/SteamVR_Editor.cs

Let me know if these should be updated as well:

    v4/Assets/SteamVR/Editor/SteamVR_Editor.cs 
    v5/Assets/SteamVR/Editor/SteamVR_Editor.cs 
