### PR TITLE
Initialize initialMappingOffset to linearMapping.value

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/LinearDrive.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/LinearDrive.cs
@@ -48,7 +48,9 @@ namespace Valve.VR.InteractionSystem
 				linearMapping = gameObject.AddComponent<LinearMapping>();
 			}
 
-			if ( repositionGameObject )
+             initialMappingOffset = linearMapping.value;
+
+             if ( repositionGameObject )
 			{
 				UpdateLinearMapping( transform );
 			}


### PR DESCRIPTION
Sometimes it is desirable to have a non-zero default, such as when using
an animation curve (-1 to 1) and you want to map the linearMapping value
(0 - 1) to the curve, but start at zero on the curve (0.5 on the linear
map).