### PR TITLE
preferences with auto-enable-VR behavior switch

### DIFF
--- a/Assets/SteamVR/Editor/SteamVR_Preferences.cs
+++ b/Assets/SteamVR/Editor/SteamVR_Preferences.cs
@@ -1,0 +1,54 @@
+//======= Copyright (c) Valve Corporation, All rights reserved. ===============
+//
+// Purpose: Preferences pane for how SteamVR plugin behaves.
+//
+//=============================================================================
+
+using UnityEngine;
+using UnityEditor;
+
+public class SteamVR_Preferences
+{
+    /// <summary>
+    /// Should SteamVR automatically enable VR when opening Unity or pressing play.
+    /// </summary>
+    public static bool AutoEnableVR
+    {
+        get
+        {
+            return EditorPrefs.GetBool("SteamVR_AutoEnableVR", true);
+        }
+        set
+        {
+            EditorPrefs.SetBool("SteamVR_AutoEnableVR", value);
+        }
+    }
+
+    [PreferenceItem("SteamVR")]
+    static void VSCodePreferencesItem()
+    {
+        EditorGUILayout.BeginVertical();
+
+        EditorGUILayout.Space();
+        
+        // EditorGUI.BeginChangeCheck();
+
+        // Automatically Enable VR
+        {
+            string title = "Automatically Enable VR";
+            string tooltip = "Should SteamVR automatically enable VR on launch and play?";
+            AutoEnableVR = EditorGUILayout.Toggle(new GUIContent(title, tooltip), AutoEnableVR);
+            string helpMessage = "To enable VR manually:\n";
+            helpMessage += "- go to Edit -> Project Settings -> Player,\n";
+            helpMessage += "- tick 'Virtual Reality Supported',\n";
+            helpMessage += "- make sure OpenVR is in the 'Virtual Reality SDKs' list.";
+            EditorGUILayout.HelpBox(helpMessage, MessageType.Info);
+        }
+        
+        // if (EditorGUI.EndChangeCheck())
+        // {
+        // }
+
+    }
+
+}

--- a/Assets/SteamVR/Editor/SteamVR_Preferences.cs.meta
+++ b/Assets/SteamVR/Editor/SteamVR_Preferences.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: bf7d473e9fcbb2b459c300b891a3e84b
+timeCreated: 1487393395
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SteamVR/Editor/SteamVR_Settings.cs
+++ b/Assets/SteamVR/Editor/SteamVR_Settings.cs
@@ -108,49 +108,53 @@ public class SteamVR_Settings : EditorWindow
 			//window.title = "SteamVR";
 		}
 
-		// Switch to native OpenVR support.
-		var updated = false;
-
-		if (!PlayerSettings.virtualRealitySupported)
+		if (SteamVR_Preferences.AutoEnableVR)
 		{
-			PlayerSettings.virtualRealitySupported = true;
-			updated = true;
-		}
+			// Switch to native OpenVR support.
+			var updated = false;
 
-#if (UNITY_5_4 || UNITY_5_3 || UNITY_5_2 || UNITY_5_1 || UNITY_5_0)
-		var devices = UnityEditorInternal.VR.VREditor.GetVREnabledDevices(BuildTargetGroup.Standalone);
-#else
-		var devices = UnityEditorInternal.VR.VREditor.GetVREnabledDevicesOnTargetGroup(BuildTargetGroup.Standalone);
-#endif
-		var hasOpenVR = false;
-		foreach (var device in devices)
-			if (device.ToLower() == "openvr")
-				hasOpenVR = true;
-
-		if (!hasOpenVR)
-		{
-			string[] newDevices;
-			if (updated)
+			if (!PlayerSettings.virtualRealitySupported)
 			{
-				newDevices = new string[] { "OpenVR" };
-			}
-			else
-			{
-				newDevices = new string[devices.Length + 1];
-				for (int i = 0; i < devices.Length; i++)
-					newDevices[i] = devices[i];
-				newDevices[devices.Length] = "OpenVR";
+				PlayerSettings.virtualRealitySupported = true;
 				updated = true;
 			}
-#if (UNITY_5_4 || UNITY_5_3 || UNITY_5_2 || UNITY_5_1 || UNITY_5_0)
-			UnityEditorInternal.VR.VREditor.SetVREnabledDevices(BuildTargetGroup.Standalone, newDevices);
-#else
-			UnityEditorInternal.VR.VREditor.SetVREnabledDevicesOnTargetGroup(BuildTargetGroup.Standalone, newDevices);
-#endif
-		}
 
-		if (updated)
-			Debug.Log("Switching to native OpenVR support.");
+#if (UNITY_5_4 || UNITY_5_3 || UNITY_5_2 || UNITY_5_1 || UNITY_5_0)
+			var devices = UnityEditorInternal.VR.VREditor.GetVREnabledDevices(BuildTargetGroup.Standalone);
+#else
+			var devices = UnityEditorInternal.VR.VREditor.GetVREnabledDevicesOnTargetGroup(BuildTargetGroup.Standalone);
+#endif
+			var hasOpenVR = false;
+			foreach (var device in devices)
+				if (device.ToLower() == "openvr")
+					hasOpenVR = true;
+
+
+			if (!hasOpenVR)
+			{
+				string[] newDevices;
+					if (updated)
+					{
+						newDevices = new string[] { "OpenVR" };
+					}
+					else
+					{
+						newDevices = new string[devices.Length + 1];
+						for (int i = 0; i < devices.Length; i++)
+							newDevices[i] = devices[i];
+						newDevices[devices.Length] = "OpenVR";
+						updated = true;
+					}
+#if (UNITY_5_4 || UNITY_5_3 || UNITY_5_2 || UNITY_5_1 || UNITY_5_0)
+				UnityEditorInternal.VR.VREditor.SetVREnabledDevices(BuildTargetGroup.Standalone, newDevices);
+#else
+				UnityEditorInternal.VR.VREditor.SetVREnabledDevicesOnTargetGroup(BuildTargetGroup.Standalone, newDevices);
+#endif
+			}
+
+			if (updated)
+				Debug.Log("Switching to native OpenVR support.");
+		}
 
 		var dlls = new string[]
 		{


### PR DESCRIPTION
Issue: #8 

This adds a SteamVR panel in the Preferences, with a switch for the auto-enabling-VR behavior. It is ON by default, so this won't change SteamVR's current out of the box behavior.

![image](https://cloud.githubusercontent.com/assets/8858/23091012/cca57ebc-f560-11e6-9753-e6d24eb63964.png)

