### PR TITLE
Fix SteamVR_UpdatePoses to work with every Unity version.

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR_Render.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Render.cs
@@ -312,20 +312,17 @@ public class SteamVR_Render : MonoBehaviour
 		}
 	}
 
-#if !(UNITY_5_6)
 	private SteamVR_UpdatePoses poseUpdater;
-#endif
 
 	void Update()
 	{
-#if !(UNITY_5_6)
 		if (poseUpdater == null)
 		{
 			var go = new GameObject("poseUpdater");
 			go.transform.parent = transform;
 			poseUpdater = go.AddComponent<SteamVR_UpdatePoses>();
 		}
-#endif
+
 		// Force controller update in case no one else called this frame to ensure prevState gets updated.
 		SteamVR_Controller.Update();
 

--- a/Assets/SteamVR/Scripts/SteamVR_UpdatePoses.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_UpdatePoses.cs
@@ -7,22 +7,26 @@
 using UnityEngine;
 using Valve.VR;
 
-[RequireComponent(typeof(Camera))]
 public class SteamVR_UpdatePoses : MonoBehaviour
 {
-#if !(UNITY_5_6)
-	void Awake()
+	void OnEnable()
 	{
-		var camera = GetComponent<Camera>();
-		camera.stereoTargetEye = StereoTargetEyeMask.None;
-		camera.clearFlags = CameraClearFlags.Nothing;
-		camera.useOcclusionCulling = false;
-		camera.cullingMask = 0;
-		camera.depth = -9999;
+		Camera.onPreCull += OnCameraPreCull;
 	}
-#endif
-	void OnPreCull()
+
+	void OnDisable()
 	{
+		Camera.onPreCull -= OnCameraPreCull;
+	}
+
+	void OnCameraPreCull(Camera cam)
+	{
+		// Only update poses for one camera
+		if (SteamVR_Render.Top().gameObject != cam.gameObject)
+		{
+			return;
+		}
+
 		var compositor = OpenVR.Compositor;
 		if (compositor != null)
 		{


### PR DESCRIPTION
The `SteamVR_UpdatePoses` script used a dummy camera to be able to
update the poses using the `MonoBehaviour.OnPreCull` message method.
This fix subscribes to the static `Camera.onPreCull` event that is fired
before **any** camera starts culling.

This means the `SteamVR_UpdatePoses` script no longer needs to be on a
game object that has a `Camera` attached to it. Therefore the
requirement for the `Camera` component, as well as the setup of the
dummy camera is removed. To make sure the poses are only updated once
and not for **every** camera all cameras attached to game objects other
than `SteamVR_Render.Top().gameObject` are ignored.