### PR TITLE
Change the StartCoroutine calls to use the method directly

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR_LoadLevel.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_LoadLevel.cs
@@ -97,7 +97,7 @@ public class SteamVR_LoadLevel : MonoBehaviour
 	public void Trigger()
 	{
 		if (!loading && !string.IsNullOrEmpty(levelName))
-			StartCoroutine("LoadLevel");
+			StartCoroutine(LoadLevel());
 	}
 
 	// Helper function to quickly and simply load a level from script.

--- a/Assets/SteamVR/Scripts/SteamVR_PlayArea.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_PlayArea.cs
@@ -258,7 +258,7 @@ public class SteamVR_PlayArea : MonoBehaviour
 			// If we want the configured bounds of the user,
 			// we need to wait for tracking.
 			if (drawInGame && size == Size.Calibrated)
-				StartCoroutine("UpdateBounds");
+				StartCoroutine(UpdateBounds());
 		}
 	}
 

--- a/Assets/SteamVR/Scripts/SteamVR_Render.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Render.cs
@@ -275,7 +275,7 @@ public class SteamVR_Render : MonoBehaviour
 
 	void OnEnable()
 	{
-		StartCoroutine("RenderLoop");
+		StartCoroutine(RenderLoop());
 		SteamVR_Events.InputFocus.Listen(OnInputFocus);
 		SteamVR_Events.System(EVREventType.VREvent_Quit).Listen(OnQuit);
 		SteamVR_Events.System(EVREventType.VREvent_RequestScreenshot).Listen(OnRequestScreenshot);


### PR DESCRIPTION
There are 3 calls of StartCoroutine that uses the method name as string.
This will cause trouble if you are using an obfuscator for your project
that renames all your private method names. By using the target method
directly (via the IEnumerator) the obfuscator can finally find this
reference too.