### PR TITLE
Silhouette improvements

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Shaders/Silhouette.shader
+++ b/Assets/SteamVR/InteractionSystem/Core/Shaders/Silhouette.shader
@@ -9,8 +9,9 @@ Shader "Valve/VR/Silhouette"
 	//-------------------------------------------------------------------------------------------------------------------------------------------------------------
 	Properties
 	{
-		g_vOutlineColor( "Outline Color", Color ) = ( .5, .5, .5, 1 )
+		_Color( "Color", Color ) = ( .5, .5, .5, 1 )
 		g_flOutlineWidth( "Outline width", Range ( .001, 0.03 ) ) = .005
+		g_flCornerAdjust( "Corner Adjustment", Range(0, 2)) = .5
 	}
 
 	//-------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -23,8 +24,9 @@ Shader "Valve/VR/Silhouette"
 		#include "UnityCG.cginc"
 
 		//-------------------------------------------------------------------------------------------------------------------------------------------------------------
-		float4 g_vOutlineColor;
+		float4 _Color;
 		float g_flOutlineWidth;
+		float g_flCornerAdjust;
 
 		//-------------------------------------------------------------------------------------------------------------------------------------------------------------
 		struct VS_INPUT
@@ -80,13 +82,21 @@ Shader "Valve/VR/Silhouette"
 		[maxvertexcount(18)]
 		void ExtrudeGs( triangle PS_INPUT inputTriangle[3], inout TriangleStream<PS_INPUT> outputStream )
 		{
+		    float3 a = normalize(inputTriangle[0].vPositionOs.xyz - inputTriangle[1].vPositionOs.xyz);
+		    float3 b = normalize(inputTriangle[1].vPositionOs.xyz - inputTriangle[2].vPositionOs.xyz);
+		    float3 c = normalize(inputTriangle[2].vPositionOs.xyz - inputTriangle[0].vPositionOs.xyz);
+
+		    inputTriangle[0].vNormalOs = inputTriangle[0].vNormalOs + normalize( a - c) * g_flCornerAdjust;
+		    inputTriangle[1].vNormalOs = inputTriangle[1].vNormalOs + normalize(-a + b) * g_flCornerAdjust;
+		    inputTriangle[2].vNormalOs = inputTriangle[2].vNormalOs + normalize(-b + c) * g_flCornerAdjust;
+
 		    PS_INPUT extrudedTriangle0 = Extrude( inputTriangle[0] );
 		    PS_INPUT extrudedTriangle1 = Extrude( inputTriangle[1] );
 		    PS_INPUT extrudedTriangle2 = Extrude( inputTriangle[2] );
 
 		    outputStream.Append( inputTriangle[0] );
 		    outputStream.Append( extrudedTriangle0 );
-		    outputStream.Append( extrudedTriangle1 );
+		    outputStream.Append( inputTriangle[1] );
 		    outputStream.Append( extrudedTriangle0 );
 		    outputStream.Append( extrudedTriangle1 );
 		    outputStream.Append( inputTriangle[1] );
@@ -94,13 +104,13 @@ Shader "Valve/VR/Silhouette"
 		    outputStream.Append( inputTriangle[1] );
 		    outputStream.Append( extrudedTriangle1 );
 		    outputStream.Append( extrudedTriangle2 );
-		    outputStream.Append( extrudedTriangle1 );
+		    outputStream.Append( inputTriangle[1] );
 		    outputStream.Append( extrudedTriangle2 );
 		    outputStream.Append( inputTriangle[2] );
 
 		    outputStream.Append( inputTriangle[2] );
 		    outputStream.Append( extrudedTriangle2 );
-		    outputStream.Append( extrudedTriangle0 );
+		    outputStream.Append(inputTriangle[0]);
 		    outputStream.Append( extrudedTriangle2 );
 		    outputStream.Append( extrudedTriangle0 );
 		    outputStream.Append( inputTriangle[0] );
@@ -109,7 +119,7 @@ Shader "Valve/VR/Silhouette"
 		//-------------------------------------------------------------------------------------------------------------------------------------------------------------
 		fixed4 MainPs( PS_INPUT i ) : SV_Target
 		{
-			return g_vOutlineColor;
+			return _Color;
 		}
 
 		//-------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -139,7 +149,7 @@ Shader "Valve/VR/Silhouette"
 				Comp always
 				Pass replace
 			}
-		
+
 			CGPROGRAM
 				#pragma vertex MainVs
 				#pragma fragment NullPs


### PR DESCRIPTION
We just incorporated this shader into EditorVR (thanks!) and had to make some changes for meshes with hard edges. The following image shows a before/after:
![image](https://cloud.githubusercontent.com/assets/19391263/24132067/d42b9812-0daf-11e7-8f61-22cc51952bbc.png)

Notice on the left that there is space between the mesh and the outline (lines 99, 107, 113), which is just the matter of using the wrong vertices and creating overlapping triangles.

Furthermore, the corners of the cube outline are "chipped" away because the normals are perpendicular on the hard edges of the cube. To account for this, I introduced a "corner adjustment" which pushed the normal along the legs of the triangle,  which essentially creates a tangent vector that we can use to bend the outlines toward each other around hard edges. If you look at the lower-right corner of the cube on the right, you will notice an artifact which is created by the diagonal edge of the two face triangles. I couldn't find a good heuristic for discarding these edges, but for reasonably thin outlines, this isn't noticeable. This wouldn't be a problem for purely quad-based meshes.

Unfortunately, this smoothing change can adversely affect smooth meshes, making them a little "furry." That is why I exposed a coefficient to adjust the amount of corner compensation.

Hope this helps!