### PR TITLE
Returning null instead of causing an IndexOutOfRangeException when using an invalid device index.

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR_Controller.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Controller.cs
@@ -148,6 +148,10 @@ public class SteamVR_Controller
 				devices[i] = new Device(i);
 		}
 
+		if (deviceIndex >= devices.Length || deviceIndex < 0) {
+			return null;
+		}
+
 		return devices[deviceIndex];
 	}
 


### PR DESCRIPTION
Returning null instead of causing an IndexOutOfRangeException when using an invalid device index.

This is especially useful when SteamVR is starting up and the devices have not connected yet.