### PR TITLE
ensure PlayArea vertices are consistent - fixes #25

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR_PlayArea.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_PlayArea.cs
@@ -65,17 +65,17 @@ public class SteamVR_PlayArea : MonoBehaviour
 
 				pRect.vCorners0.v0 =  x;
 				pRect.vCorners0.v1 =  0;
-				pRect.vCorners0.v2 =  z;
+				pRect.vCorners0.v2 =  -z;
 
-				pRect.vCorners1.v0 =  x;
+				pRect.vCorners1.v0 =  -x;
 				pRect.vCorners1.v1 =  0;
 				pRect.vCorners1.v2 = -z;
 
 				pRect.vCorners2.v0 = -x;
 				pRect.vCorners2.v1 =  0;
-				pRect.vCorners2.v2 = -z;
+				pRect.vCorners2.v2 = z;
 
-				pRect.vCorners3.v0 = -x;
+				pRect.vCorners3.v0 = x;
 				pRect.vCorners3.v1 =  0;
 				pRect.vCorners3.v2 =  z;
 


### PR DESCRIPTION
The `vertices` variable in `SteamVR_PlayArea` is inconsistent when
setting the size between Calibrated and a fixed size.

The points of the vertices are in different locations based on whether
the size is either Calibrated or a given size which causes issues when
attempting to use the `vertices` variable to generate play area
representations.

The solution is to ensure the points of the fixed size match the
positions that a calibrated play area also has.