### PR TITLE
Fix disabled controllers when re-enabling SteamVR_ControllerManager.

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR_ControllerManager.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_ControllerManager.cs
@@ -56,7 +56,7 @@ public class SteamVR_ControllerManager : MonoBehaviour
 		for (int i = 0; i < objects.Length; i++)
 		{
 			var obj = objects[i];
-			if (obj != null)
+			if (obj != null && indices[i] == OpenVR.k_unTrackedDeviceIndexInvalid)
 				obj.SetActive(false);
 		}
 


### PR DESCRIPTION
The `SteamVR_ControllerManager` script set all game objects inactive in
its `OnEnable` method. If the Controller Manager is disabled and later
enabled again turned on controllers will not be able to be used in Unity
because their game object isn't kept active.

The fix is to make sure to only disable objects that have an invalid
index currently.