### PR TITLE
fixes tracking not working on unity 2017 beta

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR_Render.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Render.cs
@@ -312,13 +312,13 @@ public class SteamVR_Render : MonoBehaviour
 		}
 	}
 
-#if !(UNITY_5_6)
+#if !(UNITY_5_6_OR_NEWER)
 	private SteamVR_UpdatePoses poseUpdater;
 #endif
 
 	void Update()
 	{
-#if !(UNITY_5_6)
+#if !(UNITY_5_6_OR_NEWER)
 		if (poseUpdater == null)
 		{
 			var go = new GameObject("poseUpdater");

--- a/Assets/SteamVR/Scripts/SteamVR_UpdatePoses.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_UpdatePoses.cs
@@ -10,7 +10,7 @@ using Valve.VR;
 [RequireComponent(typeof(Camera))]
 public class SteamVR_UpdatePoses : MonoBehaviour
 {
-#if !(UNITY_5_6)
+#if !(UNITY_5_6_OR_NEWER)
 	void Awake()
 	{
 		var camera = GetComponent<Camera>();


### PR DESCRIPTION
tracking does not work on unity 2017 if using VRTK or doing anything other than the basic examples.

Seems the cause is the directives which are not updated for newer versions of unity.