### PR TITLE
Tooltips of existing comment documentation

### DIFF
--- a/Assets/SteamVR/Editor/SteamVR_RenderModelEditor.cs
+++ b/Assets/SteamVR/Editor/SteamVR_RenderModelEditor.cs
@@ -85,7 +85,7 @@ public class SteamVR_RenderModelEditor : Editor
 		//EditorGUILayout.PropertyField(modelOverride);
 
 		GUILayout.BeginHorizontal();
-		GUILayout.Label("Model Override");
+		GUILayout.Label(new GUIContent("Model Override", "Model override is really only meant to be used in the scene view for lining things up; using it at runtime is discouraged.\n\nUse tracked device index instead to ensure the correct model is displayed for all users."));
 		var selected = EditorGUILayout.Popup(renderModelIndex, renderModelNames);
 		if (selected != renderModelIndex)
 		{

--- a/Assets/SteamVR/Scripts/SteamVR_ControllerManager.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_ControllerManager.cs
@@ -11,9 +11,11 @@ using Valve.VR;
 public class SteamVR_ControllerManager : MonoBehaviour
 {
 	public GameObject left, right;
-	public GameObject[] objects; // populate with objects you want to assign to additional controllers
+    [Tooltip("Populate with objects you want to assign to additional controllers")]
+	public GameObject[] objects;
 
-	public bool assignAllBeforeIdentified; // set to true if you want objects arbitrarily assigned to controllers before their role (left vs right) is identified
+    [Tooltip("Set to true if you want objects arbitrarily assigned to controllers before their role (left vs right) is identified")]
+	public bool assignAllBeforeIdentified;
 
 	uint[] indices; // assigned
 	bool[] connected = new bool[OpenVR.k_unMaxTrackedDeviceCount]; // controllers only

--- a/Assets/SteamVR/Scripts/SteamVR_Overlay.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Overlay.cs
@@ -14,9 +14,12 @@ public class SteamVR_Overlay : MonoBehaviour
 	public bool curved = true;
 	public bool antialias = true;
 	public bool highquality = true;
-	public float scale = 3.0f;			// size of overlay view
-	public float distance = 1.25f;		// distance from surface
-	public float alpha = 1.0f;			// opacity 0..1
+    [Tooltip("Size of overlay view.")]
+	public float scale = 3.0f;
+    [Tooltip("Distance from surface.")]
+    public float distance = 1.25f;
+    [Tooltip("Opacity")][Range(0.0f, 1.0f)]
+	public float alpha = 1.0f;
 
 	public Vector4 uvOffset = new Vector4(0, 0, 1, 1);
 	public Vector2 mouseScale = new Vector2(1, 1);

--- a/Assets/SteamVR/Scripts/SteamVR_RenderModel.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_RenderModel.cs
@@ -14,18 +14,19 @@ using Valve.VR;
 public class SteamVR_RenderModel : MonoBehaviour
 {
 	public SteamVR_TrackedObject.EIndex index = SteamVR_TrackedObject.EIndex.None;
-	public string modelOverride;
+    [Tooltip("Model override is really only meant to be used in the scene view for lining things up; using it at runtime is discouraged.  Use tracked device index instead to ensure the correct model is displayed for all users.")]
+    public string modelOverride;
 
-	// Shader to apply to model.
+	[Tooltip("Shader to apply to model.")]
 	public Shader shader;
 
-	// Enable to print out when render models are loaded.
+    [Tooltip("Enable to print out when render models are loaded.")]
 	public bool verbose = false;
 
-	// If available, break down into separate components instead of loading as a single mesh.
+    [Tooltip("If available, break down into separate components instead of loading as a single mesh.")]
 	public bool createComponents = true;
 
-	// Update transforms of components at runtime to reflect user action.
+	[Tooltip("Update transforms of components at runtime to reflect user action.")]
 	public bool updateDynamically = true;
 
 	// Additional controller settings for showing scrollwheel, etc.

--- a/Assets/SteamVR/Scripts/SteamVR_TrackedObject.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_TrackedObject.cs
@@ -31,7 +31,8 @@ public class SteamVR_TrackedObject : MonoBehaviour
 	}
 
 	public EIndex index;
-	public Transform origin; // if not set, relative to parent
+    [Tooltip("If not set, relative to parent")]
+	public Transform origin;
     public bool isValid = false;
 
 	private void OnNewPoses(TrackedDevicePose_t[] poses)


### PR DESCRIPTION
Several files have documentation in the form of comments. Unity has support for tooltips, which can make this information available inside the Unity Editor, without having to view the source code.

One comment also mentioned a 0-1 range, which Unity also has a built-in attribute for, turning the number into a convenient slider.