### PR TITLE
Adding ability to build on SpatialOS without modifying source

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR.cs
+++ b/Assets/SteamVR/Scripts/SteamVR.cs
@@ -19,9 +19,13 @@ public class SteamVR : System.IDisposable
 	{
 		get
 		{
+#if UNITY_STANDALONE_LINUX
+			return false;
+#else
 			if (!UnityEngine.VR.VRSettings.enabled)
 				enabled = false;
 			return _enabled;
+#endif
 		}
 		set
 		{
@@ -58,7 +62,11 @@ public class SteamVR : System.IDisposable
 
 	public static bool usingNativeSupport
 	{
+#if UNITY_STANDALONE_LINUX
+        get { return false; }
+#else
 		get { return UnityEngine.VR.VRDevice.GetNativePtr() != System.IntPtr.Zero; }
+#endif
 	}
 
 	static SteamVR CreateInstance()

--- a/Assets/SteamVR/Scripts/SteamVR_Camera.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Camera.cs
@@ -33,8 +33,13 @@ public class SteamVR_Camera : MonoBehaviour
 
 	static public float sceneResolutionScale
 	{
+#if UNITY_STANDALONE_LINUX
+		get { return 1f; }
+		set { }
+#else
 		get { return UnityEngine.VR.VRSettings.renderScale; }
 		set { UnityEngine.VR.VRSettings.renderScale = value; }
+#endif
 	}
 
 	#region Enable / Disable


### PR DESCRIPTION
Improbable's SpatialOS runs on Linux. The code base for the client and the server is shared so SteamVR needs to be able to build for Linux.