### PR TITLE
Allow Throwable extensions

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/Throwable.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/Throwable.cs
@@ -63,7 +63,7 @@ namespace Valve.VR.InteractionSystem
 
 
 		//-------------------------------------------------
-		private void OnHandHoverBegin( Hand hand )
+		protected virtual void OnHandHoverBegin( Hand hand )
 		{
 			bool showHint = false;
 
@@ -91,14 +91,14 @@ namespace Valve.VR.InteractionSystem
 
 
 		//-------------------------------------------------
-		private void OnHandHoverEnd( Hand hand )
+		protected virtual void OnHandHoverEnd( Hand hand )
 		{
 			ControllerButtonHints.HideButtonHint( hand, Valve.VR.EVRButtonId.k_EButton_SteamVR_Trigger );
 		}
 
 
 		//-------------------------------------------------
-		private void HandHoverUpdate( Hand hand )
+		protected virtual void HandHoverUpdate( Hand hand )
 		{
 			//Trigger got pressed
 			if ( hand.GetStandardInteractionButtonDown() )
@@ -109,7 +109,7 @@ namespace Valve.VR.InteractionSystem
 		}
 
 		//-------------------------------------------------
-		private void OnAttachedToHand( Hand hand )
+		protected virtual void OnAttachedToHand( Hand hand )
 		{
 			attached = true;
 
@@ -154,7 +154,7 @@ namespace Valve.VR.InteractionSystem
 
 
 		//-------------------------------------------------
-		private void OnDetachedFromHand( Hand hand )
+		protected virtual void OnDetachedFromHand( Hand hand )
 		{
 			attached = false;
 
@@ -199,7 +199,7 @@ namespace Valve.VR.InteractionSystem
 
 
 		//-------------------------------------------------
-		private void HandAttachedUpdate( Hand hand )
+		protected virtual void HandAttachedUpdate( Hand hand )
 		{
 			//Trigger got released
 			if ( !hand.GetStandardInteractionButton() )


### PR DESCRIPTION
The current Throwable implementation allows for subclassing but the use of private methods prevents the subclass from overriding the methods used to handle messages from Hand.cs. Changing the definition allows the subclass the ability to override each method and still be able to call the parent classes implementation as well. It's possible to use the onPickUp or onDetachFromHand but this can be limiting.