### PR TITLE
Changed VR.VRSettings to XR.XRSettings

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR.cs
+++ b/Assets/SteamVR/Scripts/SteamVR.cs
@@ -19,7 +19,7 @@ public class SteamVR : System.IDisposable
 	{
 		get
 		{
-			if (!UnityEngine.VR.VRSettings.enabled)
+			if (!UnityEngine.XR.XRSettings.enabled)
 				enabled = false;
 			return _enabled;
 		}

--- a/Assets/SteamVR/Scripts/SteamVR.cs
+++ b/Assets/SteamVR/Scripts/SteamVR.cs
@@ -58,7 +58,7 @@ public class SteamVR : System.IDisposable
 
 	public static bool usingNativeSupport
 	{
-		get { return UnityEngine.VR.VRDevice.GetNativePtr() != System.IntPtr.Zero; }
+		get { return UnityEngine.XR.XRDevice.GetNativePtr() != System.IntPtr.Zero; }
 	}
 
 	static SteamVR CreateInstance()

--- a/Assets/SteamVR/Scripts/SteamVR_Camera.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Camera.cs
@@ -33,8 +33,8 @@ public class SteamVR_Camera : MonoBehaviour
 
 	static public float sceneResolutionScale
 	{
-		get { return UnityEngine.VR.VRSettings.renderScale; }
-		set { UnityEngine.VR.VRSettings.renderScale = value; }
+		get { return UnityEngine.XR.XRSettings.renderScale; }
+		set { UnityEngine.XR.XRSettings.renderScale = value; }
 	}
 
 	#region Enable / Disable


### PR DESCRIPTION
Fixing the warning dialogue and Unitys autofix for the Change from `VR.VRSettings` to `XR.XRSettings`.