### PR TITLE
Continue processing hands even when time is paused

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/Hand.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/Hand.cs
@@ -686,6 +686,12 @@ namespace Valve.VR.InteractionSystem
 			{
 				hoveringInteractable.SendMessage( "HandHoverUpdate", this, SendMessageOptions.DontRequireReceiver );
 			}
+			
+			// Process hand movements here when time is paused and FixedUpdate() is not being called
+			if ( Time.timeScale == 0.0f )
+			{
+				UpdateHandPoses();
+			}
 		}
 
 


### PR DESCRIPTION
Since UpdateHandPoses() is called from FixedUpdate(), this is not called when the game is paused using the common method of setting Time.timeScale to 0.0f.  This change ensures that UpdateHandPoses() is still called while time is paused.