### PR TITLE
Fix Black Texture RenderModel issue in Experimental (.NET 4.6 Equivalent)

### DIFF
--- a/Assets/SteamVR/Plugins/openvr_api.cs
+++ b/Assets/SteamVR/Plugins/openvr_api.cs
@@ -4645,15 +4645,15 @@ public enum EVRScreenshotError
 }
 [StructLayout(LayoutKind.Sequential)] public struct RenderModel_TextureMap_t
 {
-	public char unWidth;
-	public char unHeight;
+	public ushort unWidth;
+	public ushort unHeight;
 	public IntPtr rubTextureMapData; // const uint8_t *
 }
 // This structure is for backwards binary compatibility on Linux and OSX only
 [StructLayout(LayoutKind.Sequential, Pack = 4)] public struct RenderModel_TextureMap_t_Packed
 {
-	public char unWidth;
-	public char unHeight;
+	public ushort unWidth;
+	public ushort unHeight;
 	public IntPtr rubTextureMapData; // const uint8_t *
 	public RenderModel_TextureMap_t_Packed(RenderModel_TextureMap_t unpacked)
 	{


### PR DESCRIPTION
When Unity Scripting Runtime Version is set to "Experimental (.NET 4.6 Equivalent)", textures retrieved by SteamVR_RenderModel showed up black. Reason was char unWidth/unHeight returned odd values (e.g. 0, 8). Using ushort fixes this and also works with "Stable (.NET 3.5 Equivalent)".