### PR TITLE
fix(RenderModel): models at startup with dashboard

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR_RenderModel.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_RenderModel.cs
@@ -150,7 +150,6 @@ public class SteamVR_RenderModel : MonoBehaviour
 		var s = buffer.ToString();
 		if (renderModelName != s)
 		{
-			renderModelName = s;
 			StartCoroutine(SetModelAsync(s));
 		}
 	}
@@ -265,6 +264,7 @@ public class SteamVR_RenderModel : MonoBehaviour
 		}
 
 		bool success = SetModel(renderModelName);
+		this.renderModelName = renderModelName;
 		SteamVR_Events.RenderModelLoaded.Send(this, success);
 	}
 


### PR DESCRIPTION
If a user brings up the SteamVR dashboard right at the last second before the Unity title connects to OpenVR the tracked objects' game objects are turned off and on multiple times. This in turn results in the asynchronous loading of the tracked objects' render models to be cancelled by Unity as Unity stops coroutines running on a component when the game object gets deactivated. Thus a user is not seeing any controllers inside of the just started Unity title.

This fix ignores the additional game object (de)activation happening in the above scenario and instead ensures the component loading the render model only sets its internal state to signal that a particular render model is loaded **after** it actually was able to do so completely. With this fix applied Unity cancelling the render model load coroutine is not an issue anymore as the render model component will be retrying the next time the game object is activated again.