### PR TITLE
fix(TrackedDevice): startup with dashboard

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR_ControllerManager.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_ControllerManager.cs
@@ -4,6 +4,7 @@
 //
 //=============================================================================
 
+using System.Collections;
 using UnityEngine;
 using Valve.VR;
 
@@ -86,6 +87,8 @@ public class SteamVR_ControllerManager : MonoBehaviour
 		inputFocusAction.enabled = true;
 		deviceConnectedAction.enabled = true;
 		trackedDeviceRoleChangedAction.enabled = true;
+
+		StartCoroutine(HandleInitialInputFocus());
 	}
 
 	void OnDisable()
@@ -124,6 +127,16 @@ public class SteamVR_ControllerManager : MonoBehaviour
 					HideObject(obj.transform, hiddenPrefix + label + hiddenPostfix);
 				}
 			}
+		}
+	}
+
+	IEnumerator HandleInitialInputFocus()
+	{
+		yield return new WaitForEndOfFrame();
+
+		if (!OpenVR.System.IsInputAvailable())
+		{
+			OnInputFocus(false);
 		}
 	}
 


### PR DESCRIPTION
If the SteamVR dashboard is visible while the Unity title starts up the game objects for tracked devices are turned on, even though the input focus observation will turn them off once anything has input focus exclusively like the dashboard.

To ensure the initial input focus state is handled properly on startup this fix uses the OpenVR API to figure out whether the input is currently available and if it's not the same method that handles any change in input focus is called, ensuring the game objects state is as intended. The fix has to wait for the end of the frame as the existing SteamVR plugin uses `BroadcastMessage` to set device indices on any component that responds to that setter method. Unity doesn't forward messages on deactivated game objects so without waiting this fix would result in the index of the tracked objects not being set properly.