### PR TITLE
LinearAnimation bug fix

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/LinearAnimation.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/LinearAnimation.cs
@@ -55,7 +55,7 @@ namespace Valve.VR.InteractionSystem
 			//No need to set the anim if our value hasn't changed.
 			if ( value != lastValue )
 			{
-				animState.time = value / animLength;
+				animState.time = value * animLength;
 			}
 
 			lastValue = value;


### PR DESCRIPTION
LinearAnimation should multiply the LinearMapping value by the total clip time, and instead it divides.