### PR TITLE
Extends Teleport to support NavMesh Areas

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Samples/Scripts/TeleportNavMeshExample.cs
+++ b/Assets/SteamVR/InteractionSystem/Samples/Scripts/TeleportNavMeshExample.cs
@@ -1,0 +1,62 @@
+//======= Copyright (c) Valve Corporation, All rights reserved. ===============
+//
+// Purpose: Demonstrates how to Teleport onto NavMesh Walkable
+//
+//=============================================================================
+
+using UnityEngine;
+using UnityEngine.AI;
+using Valve.VR.InteractionSystem;
+
+namespace Valve.VR.InteractionSystem
+{
+  public class TeleportNavMeshExample : TeleportMarkerBase
+  {
+      [Tooltip("Adjust NavMesh Sensitivity")]
+      public float range = 0.25f;
+
+      public override void Highlight(bool highlight)
+      {
+
+      }
+
+      public override void SetAlpha(float tintAlpha, float alphaPercent)
+      {
+
+      }
+
+      bool RandomPoint(Vector3 center, float range, out Vector3 result)
+      {
+          Vector3 randomPoint = center;
+          NavMeshHit hit;
+          if (NavMesh.SamplePosition(randomPoint, out hit, range, 1 << NavMesh.GetAreaFromName("Walkable")))
+          {
+              result = hit.position;
+              return true;
+          }
+          result = Vector3.zero;
+          return false;
+      }
+
+      public override bool ShouldActivate(Vector3 playerPosition)
+      {
+          return true;
+      }
+
+      public override bool ShouldMovePlayer()
+      {
+          return !locked;
+      }
+
+      public override void UpdateVisuals()
+      {
+      }
+
+      public override bool ValidateLocation(Vector3 pointerPosition)
+      {
+          var location = Vector3.zero;
+          SetLocked(!RandomPoint(pointerPosition, range, out location));
+          return locked;
+      }
+  }
+}

--- a/Assets/SteamVR/InteractionSystem/Teleport/Scripts/Teleport.cs
+++ b/Assets/SteamVR/InteractionSystem/Teleport/Scripts/Teleport.cs
@@ -345,6 +345,7 @@ namespace Valve.VR.InteractionSystem
 
 			if ( hitTeleportMarker != null ) //Hit a teleport marker
 			{
+				hitTeleportMarker.ValidateLocation(hitInfo.point);
 				if ( hitTeleportMarker.locked )
 				{
 					teleportArc.SetColor( pointerLockedColor );
@@ -647,7 +648,10 @@ namespace Valve.VR.InteractionSystem
 			{
 				if ( teleportMarker != null && teleportMarker.markerActive && teleportMarker.gameObject != null )
 				{
-					teleportMarker.gameObject.SetActive( false );
+					if (teleportMarker.VisibleOnTeleportOnly)
+                    			{
+                        			teleportMarker.gameObject.SetActive(false);
+					}
 				}
 			}
 

--- a/Assets/SteamVR/InteractionSystem/Teleport/Scripts/TeleportMarkerBase.cs
+++ b/Assets/SteamVR/InteractionSystem/Teleport/Scripts/TeleportMarkerBase.cs
@@ -13,6 +13,7 @@ namespace Valve.VR.InteractionSystem
 	{
 		public bool locked = false;
 		public bool markerActive = true;
+		public bool VisibleOnTeleportOnly = true;
 
 		//-------------------------------------------------
 		public virtual bool showReticle
@@ -36,6 +37,12 @@ namespace Valve.VR.InteractionSystem
 		//-------------------------------------------------
 		public virtual void TeleportPlayer( Vector3 pointedAtPosition )
 		{
+		}
+		
+		//-------------------------------------------------
+		public virtual void ValidateLocation( Vector3 pointedAtPosition )
+		{
+			return true;
 		}
 
 


### PR DESCRIPTION
The following changes allow users to extend the built in teleport system by providing a few more overrides to TeleportMarkerBase. Namely users can inherit from base and provide pointer location validation. 

This also extends TeleportMarkerBase to give users the option to not have meshes that have been designated as TeleportMarkers disabled. 