### PR TITLE
Formatted SteamVR Debug.Log* statements to be easily identified in the Unity console

### DIFF
--- a/Assets/SteamVR/Editor/SteamVR_UnitySettingsWindow.cs
+++ b/Assets/SteamVR/Editor/SteamVR_UnitySettingsWindow.cs
@@ -164,7 +164,7 @@ namespace Valve.VR
                 }
 
                 if (updated)
-                    Debug.Log("Switching to native OpenVR support.");
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Switching to native OpenVR support.");
             }
 
             var dlls = new string[]
@@ -179,7 +179,7 @@ namespace Valve.VR
                     continue;
 
                 if (AssetDatabase.DeleteAsset("Assets/" + path))
-                    Debug.Log("Deleting " + path);
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Deleting " + path);
                 else
                 {
                     Debug.Log(path + " in use; cannot delete.  Please restart Unity to complete upgrade.");

--- a/Assets/SteamVR/Extras/SteamVR_GazeTracker.cs
+++ b/Assets/SteamVR/Extras/SteamVR_GazeTracker.cs
@@ -53,8 +53,8 @@ namespace Valve.VR.Extras
                 {
                     Vector3 intersect = hmdTrackedObject.position + hmdTrackedObject.forward * enter;
                     float dist = Vector3.Distance(intersect, transform.position);
-                    //Debug.Log("Gaze dist = " + dist);
-                    if (dist < gazeInCutoff && !isInGaze)
+					//Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Gaze dist = " + dist);
+					if (dist < gazeInCutoff && !isInGaze)
                     {
                         isInGaze = true;
                         GazeEventArgs gazeEventArgs;

--- a/Assets/SteamVR/Input/Editor/SteamVR_CopyExampleInputFiles.cs
+++ b/Assets/SteamVR/Input/Editor/SteamVR_CopyExampleInputFiles.cs
@@ -55,11 +55,11 @@ namespace Valve.VR
                         try
                         {
                             File.Copy(file, newPath, false);
-                            Debug.Log("[SteamVR Input] Copied example input JSON to path: " + newPath);
+                            Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Copied example input JSON to path: " + newPath);
                         }
                         catch
                         {
-                            Debug.LogError("[SteamVR Input] Could not copy file: " + file + " to path: " + newPath);
+                            Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> Could not copy file: " + file + " to path: " + newPath);
                         }
                     }
 

--- a/Assets/SteamVR/Input/Editor/SteamVR_Input_EditorWindow.cs
+++ b/Assets/SteamVR/Input/Editor/SteamVR_Input_EditorWindow.cs
@@ -776,7 +776,7 @@ namespace Valve.VR
 
             File.WriteAllText(SteamVR_Input.actionsFilePath, json);
 
-            Debug.Log("[SteamVR Input] Saved actions manifest successfully.");
+            Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Saved actions manifest successfully.");
 
             SteamVR_Input_Generator.BeginGeneration();
         }

--- a/Assets/SteamVR/Input/Editor/SteamVR_Input_Generator.cs
+++ b/Assets/SteamVR/Input/Editor/SteamVR_Input_Generator.cs
@@ -90,7 +90,7 @@ namespace Valve.VR
 
             if (tryNumber > 1)
             {
-                Debug.LogError("[SteamVR] There was an error in input generation. Aborting.");
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> There was an error in input generation. Aborting.");
                 CancelGeneration();
             }
 
@@ -159,7 +159,7 @@ namespace Valve.VR
 
                 if (tryNumber > 1)
                 {
-                    Debug.LogError("[SteamVR] There was an error in input generation. Aborting.");
+                    Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> There was an error in input generation. Aborting.");
                     CancelGeneration();
                 }
 
@@ -223,7 +223,7 @@ namespace Valve.VR
             string actionsFullpath = Path.Combine(GetClassPath(), steamVRInputActionsClass + ".cs");
             string actionSetsFullpath = Path.Combine(GetClassPath(), steamVRInputActionSetsClass + ".cs");
 
-            Debug.LogFormat("[SteamVR Input] Created input script main classes: {0} and {1}", actionsFullpath, actionSetsFullpath);
+            Debug.LogFormat("<b><color=#1b2838>[SteamVR Input]</color></b> Created input script main classes: {0} and {1}", actionsFullpath, actionSetsFullpath);
 
             SetNextGenerationStep(GenerationSteps.GeneratingActions);
         }
@@ -339,11 +339,11 @@ namespace Valve.VR
                         EditorSceneManager.SaveOpenScenes();
                         processedScenes.Add(path);
 
-                        Debug.Log("[SteamVR Input] Assigned default actions in scene: " + path);
+                        Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Assigned default actions in scene: " + path);
                     }
                     else
                     {
-                        Debug.LogWarning("[SteamVR Input] Generation could not open scene at: " + path);
+                        Debug.LogWarning("<b><color=#1b2838>[SteamVR Input]</color></b> Generation could not open scene at: " + path);
                     }
                 }
             }
@@ -364,11 +364,11 @@ namespace Valve.VR
                                 AssignDefaultsInScene();
                                 EditorSceneManager.SaveOpenScenes();
 
-                                Debug.Log("[SteamVR Input] Assigned default actions in scene: " + scenePath);
+                                Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Assigned default actions in scene: " + scenePath);
                             }
                             else
                             {
-                                Debug.LogWarning("[SteamVR Input] Scene in build settings could not be opened: " + scenePath);
+                                Debug.LogWarning("<b><color=#1b2838>[SteamVR Input]</color></b> Scene in build settings could not be opened: " + scenePath);
                             }
                         }
                     }
@@ -378,7 +378,7 @@ namespace Valve.VR
             if (string.IsNullOrEmpty(activeScenePath) == false)
             {
                 EditorSceneManager.OpenScene(activeScenePath, OpenSceneMode.Single);
-                Debug.Log("[SteamVR Input] Returning editor to previous scene: " + activeScenePath);
+                Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Returning editor to previous scene: " + activeScenePath);
             }
         }
 
@@ -592,7 +592,7 @@ namespace Valve.VR
 
             SteamVR_Input_EditorWindow.ClearProgressBar();
 
-            Debug.Log("[SteamVR Input] Action generation complete!");
+            Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Action generation complete!");
         }
 
         private static void CreateActionsSubFolder()
@@ -639,7 +639,7 @@ namespace Valve.VR
             AssetDatabase.SaveAssets();
 
             string folderPath = GetSubFolderPath();
-            Debug.LogFormat("[SteamVR Input] Created {0} action set objects and {1} action objects in: {2}", SteamVR_Input.actionFile.action_sets.Count, SteamVR_Input.actionFile.actions.Count, folderPath);
+            Debug.LogFormat("<b><color=#1b2838>[SteamVR Input]</color></b> Created {0} action set objects and {1} action objects in: {2}", SteamVR_Input.actionFile.action_sets.Count, SteamVR_Input.actionFile.actions.Count, folderPath);
         }
 
         private static SteamVR_Action CreateScriptableAction(SteamVR_Input_ActionFile_Action action, SteamVR_ActionSet set)
@@ -847,7 +847,7 @@ namespace Valve.VR
                 AssetDatabase.DeleteAsset(assets[assetIndex]);
             }
 
-            Debug.LogFormat("[SteamVR] Deleted {0} actions at path: {1}", assets.Length, folderPath);
+            Debug.LogFormat("<b><color=#1b2838>[SteamVR Input]</color></b> Deleted {0} actions at path: {1}", assets.Length, folderPath);
         }
 
         private static void DeleteActionClass(string className)
@@ -856,11 +856,11 @@ namespace Valve.VR
             if (File.Exists(filePath) == true)
             {
                 AssetDatabase.DeleteAsset(filePath);
-                Debug.Log("[SteamVR] Deleted: " + filePath);
+                Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Deleted: " + filePath);
             }
             else
             {
-                Debug.Log("[SteamVR] No file found at: " + filePath);
+                Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> No file found at: " + filePath);
             }
         }
 
@@ -941,7 +941,7 @@ namespace Valve.VR
 
             // Build the output file name.
             string fullSourceFilePath = fullPath;
-            //Debug.Log("[SteamVR] Writing class to: " + fullSourceFilePath);
+            //Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Writing class to: " + fullSourceFilePath);
 
             string path = GetClassPath();
             string[] parts = path.Split('/');
@@ -952,7 +952,7 @@ namespace Valve.VR
                 if (Directory.Exists(directoryPath) == false)
                 {
                     Directory.CreateDirectory(directoryPath);
-                    //Debug.Log("[SteamVR] Created directory: " + directoryPath);
+                    //Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Created directory: " + directoryPath);
                 }
             }
 
@@ -973,7 +973,7 @@ namespace Valve.VR
                 tw.Close();
             }
 
-            //Debug.Log("[SteamVR] Complete! Input class at: " + fullSourceFilePath);
+            //Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Complete! Input class at: " + fullSourceFilePath);
         }
 
         private const string getActionMethodParamName = "path";
@@ -1302,7 +1302,7 @@ namespace Valve.VR
         private static CodeMemberField CreateField(CodeTypeDeclaration inputClass, string fieldName, Type fieldType, bool isStatic)
         {
             if (fieldType == null)
-                Debug.Log("null fieldType");
+                Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> null fieldType");
 
             CodeMemberField field = new CodeMemberField();
             field.Name = fieldName;

--- a/Assets/SteamVR/Input/Editor/SteamVR_Input_PostProcessBuild.cs
+++ b/Assets/SteamVR/Input/Editor/SteamVR_Input_PostProcessBuild.cs
@@ -42,11 +42,11 @@ namespace Valve.VR
                         //UpdateAppKey(newFilePath, fileInfo.Name);
                         RemoveAppKey(newFilePath, fileInfo.Name);
 
-                        Debug.Log("[SteamVR] Copied (overwrote) SteamVR Input file at build path: " + newFilePath);
+                        Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Copied (overwrote) SteamVR Input file at build path: " + newFilePath);
                     }
                     else
                     {
-                        Debug.Log("[SteamVR] Skipped writing existing file at build path: " + newFilePath);
+                        Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Skipped writing existing file at build path: " + newFilePath);
                     }
                 }
                 else
@@ -55,7 +55,7 @@ namespace Valve.VR
                     //UpdateAppKey(newFilePath, fileInfo.Name);
                     RemoveAppKey(newFilePath, fileInfo.Name);
 
-                    Debug.Log("[SteamVR] Copied SteamVR Input file to build folder: " + newFilePath);
+                    Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Copied SteamVR Input file to build folder: " + newFilePath);
                 }
 
             }

--- a/Assets/SteamVR/Input/SteamVR_Action.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action.cs
@@ -54,9 +54,9 @@ namespace Valve.VR
             EVRInputError err = OpenVR.Input.GetActionHandle(fullPath.ToLower(), ref handle);
 
             if (err != EVRInputError.None)
-                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetActionHandle (" + fullPath + ") error: " + err.ToString());
-			//else <b><color=#1b2838>[SteamVR]</color></b> andle: " + handle);
-		}
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> GetActionHandle (" + fullPath + ") error: " + err.ToString());
+            //else <b><color=#1b2838>[SteamVR Input]</color></b> andle: " + handle);
+        }
         
         protected virtual void InitializeDictionaries(SteamVR_Input_Sources source)
         {

--- a/Assets/SteamVR/Input/SteamVR_Action.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action.cs
@@ -54,9 +54,9 @@ namespace Valve.VR
             EVRInputError err = OpenVR.Input.GetActionHandle(fullPath.ToLower(), ref handle);
 
             if (err != EVRInputError.None)
-                Debug.LogError("GetActionHandle (" + fullPath + ") error: " + err.ToString());
-            //else Debug.Log("handle: " + handle);
-        }
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetActionHandle (" + fullPath + ") error: " + err.ToString());
+			//else <b><color=#1b2838>[SteamVR]</color></b> andle: " + handle);
+		}
         
         protected virtual void InitializeDictionaries(SteamVR_Input_Sources source)
         {

--- a/Assets/SteamVR/Input/SteamVR_ActionSet.cs
+++ b/Assets/SteamVR/Input/SteamVR_ActionSet.cs
@@ -63,7 +63,7 @@ namespace Valve.VR
             EVRInputError err = OpenVR.Input.GetActionSetHandle(fullPath.ToLower(), ref handle);
 
             if (err != EVRInputError.None)
-                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetActionSetHandle (" + fullPath + ") error: " + err.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> GetActionSetHandle (" + fullPath + ") error: " + err.ToString());
 
             activeActionSetSize = (uint)(Marshal.SizeOf(typeof(VRActiveActionSet_t)));
         }
@@ -175,13 +175,13 @@ namespace Valve.VR
                 {
                     EVRInputError err = OpenVR.Input.UpdateActionState(activeActionSets, activeActionSetSize);
                     if (err != EVRInputError.None)
-                        Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> UpdateActionState error: " + err.ToString());
-					//else Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Action sets activated: " + activeActionSets.Length);
-				}
+                        Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> UpdateActionState error: " + err.ToString());
+                    //else Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Action sets activated: " + activeActionSets.Length);
+                }
                 else
                 {
-					//Debug.LogWarning("<b><color=#1b2838>[SteamVR]</color></b> No sets active");
-				}
+                    //Debug.LogWarning("<b><color=#1b2838>[SteamVR Input]</color></b> No sets active");
+                }
             }
         }
 

--- a/Assets/SteamVR/Input/SteamVR_ActionSet.cs
+++ b/Assets/SteamVR/Input/SteamVR_ActionSet.cs
@@ -63,7 +63,7 @@ namespace Valve.VR
             EVRInputError err = OpenVR.Input.GetActionSetHandle(fullPath.ToLower(), ref handle);
 
             if (err != EVRInputError.None)
-                Debug.LogError("GetActionSetHandle (" + fullPath + ") error: " + err.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetActionSetHandle (" + fullPath + ") error: " + err.ToString());
 
             activeActionSetSize = (uint)(Marshal.SizeOf(typeof(VRActiveActionSet_t)));
         }
@@ -175,13 +175,13 @@ namespace Valve.VR
                 {
                     EVRInputError err = OpenVR.Input.UpdateActionState(activeActionSets, activeActionSetSize);
                     if (err != EVRInputError.None)
-                        Debug.LogError("UpdateActionState error: " + err.ToString());
-                    //else Debug.Log("Action sets activated: " + activeActionSets.Length);
-                }
+                        Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> UpdateActionState error: " + err.ToString());
+					//else Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Action sets activated: " + activeActionSets.Length);
+				}
                 else
                 {
-                    //Debug.LogWarning("No sets active");
-                }
+					//Debug.LogWarning("<b><color=#1b2838>[SteamVR]</color></b> No sets active");
+				}
             }
         }
 

--- a/Assets/SteamVR/Input/SteamVR_Action_Boolean.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Boolean.cs
@@ -57,7 +57,7 @@ namespace Valve.VR
 
             EVRInputError err = OpenVR.Input.GetDigitalActionData(handle, ref tempActionData, actionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
-                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetDigitalActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> GetDigitalActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
 
             actionData[inputSource] = tempActionData;
             changed[inputSource] = tempActionData.bChanged;

--- a/Assets/SteamVR/Input/SteamVR_Action_Boolean.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Boolean.cs
@@ -57,7 +57,7 @@ namespace Valve.VR
 
             EVRInputError err = OpenVR.Input.GetDigitalActionData(handle, ref tempActionData, actionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
-                Debug.LogError("GetDigitalActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetDigitalActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
 
             actionData[inputSource] = tempActionData;
             changed[inputSource] = tempActionData.bChanged;

--- a/Assets/SteamVR/Input/SteamVR_Action_In.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_In.cs
@@ -146,7 +146,7 @@ namespace Valve.VR
                 EVRInputError err = OpenVR.Input.GetOriginTrackedDeviceInfo(activeOrigin[inputSource], ref inputOriginInfo, inputOriginInfo_size);
 
                 if (err != EVRInputError.None)
-                    Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetOriginTrackedDeviceInfo error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString() + " activeOrigin: " + activeOrigin[inputSource].ToString() + " active: " + active[inputSource]);
+                    Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> GetOriginTrackedDeviceInfo error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString() + " activeOrigin: " + activeOrigin[inputSource].ToString() + " active: " + active[inputSource]);
 
                 lastInputOriginInfo[inputSource] = inputOriginInfo;
                 lastOriginGetFrame[inputSource] = Time.frameCount;

--- a/Assets/SteamVR/Input/SteamVR_Action_In.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_In.cs
@@ -146,7 +146,7 @@ namespace Valve.VR
                 EVRInputError err = OpenVR.Input.GetOriginTrackedDeviceInfo(activeOrigin[inputSource], ref inputOriginInfo, inputOriginInfo_size);
 
                 if (err != EVRInputError.None)
-                    Debug.LogError("GetOriginTrackedDeviceInfo error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString() + " activeOrigin: " + activeOrigin[inputSource].ToString() + " active: " + active[inputSource]);
+                    Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetOriginTrackedDeviceInfo error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString() + " activeOrigin: " + activeOrigin[inputSource].ToString() + " active: " + active[inputSource]);
 
                 lastInputOriginInfo[inputSource] = inputOriginInfo;
                 lastOriginGetFrame[inputSource] = Time.frameCount;

--- a/Assets/SteamVR/Input/SteamVR_Action_Pose.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Pose.cs
@@ -93,7 +93,7 @@ namespace Valve.VR
             EVRInputError err = OpenVR.Input.GetPoseActionData(handle, universeOrigin, predictedSecondsFromNow, ref tempPoseActionData, poseActionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
             {
-                Debug.LogError("GetPoseActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetPoseActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
             }
             
             poseActionData[inputSource] = tempPoseActionData;
@@ -137,7 +137,7 @@ namespace Valve.VR
             EVRInputError err = OpenVR.Input.GetPoseActionData(handle, universeOrigin, secondsFromNow, ref tempPoseActionData, poseActionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
             {
-                Debug.LogError("GetPoseActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString()); //todo: this should be an error
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetPoseActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString()); //todo: this should be an error
                 
                 velocity = Vector3.zero;
                 angularVelocity = Vector3.zero;
@@ -165,7 +165,7 @@ namespace Valve.VR
                 }
                 else
                 {
-                    Debug.LogError("GetPoseActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString()); //todo: this should be an error
+                    Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetPoseActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString()); //todo: this should be an error
                 }
 
                 velocity = Vector3.zero;

--- a/Assets/SteamVR/Input/SteamVR_Action_Pose.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Pose.cs
@@ -93,7 +93,7 @@ namespace Valve.VR
             EVRInputError err = OpenVR.Input.GetPoseActionData(handle, universeOrigin, predictedSecondsFromNow, ref tempPoseActionData, poseActionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
             {
-                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetPoseActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> GetPoseActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
             }
             
             poseActionData[inputSource] = tempPoseActionData;
@@ -137,7 +137,7 @@ namespace Valve.VR
             EVRInputError err = OpenVR.Input.GetPoseActionData(handle, universeOrigin, secondsFromNow, ref tempPoseActionData, poseActionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
             {
-                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetPoseActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString()); //todo: this should be an error
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> GetPoseActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString()); //todo: this should be an error
                 
                 velocity = Vector3.zero;
                 angularVelocity = Vector3.zero;
@@ -165,7 +165,7 @@ namespace Valve.VR
                 }
                 else
                 {
-                    Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetPoseActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString()); //todo: this should be an error
+                    Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> GetPoseActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString()); //todo: this should be an error
                 }
 
                 velocity = Vector3.zero;

--- a/Assets/SteamVR/Input/SteamVR_Action_Single.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Single.cs
@@ -47,7 +47,7 @@ namespace Valve.VR
 
             EVRInputError err = OpenVR.Input.GetAnalogActionData(handle, ref tempActionData, actionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
-                Debug.LogError("GetAnalogActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetAnalogActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
 
             active[inputSource] = tempActionData.bActive;
             activeOrigin[inputSource] = tempActionData.activeOrigin;

--- a/Assets/SteamVR/Input/SteamVR_Action_Single.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Single.cs
@@ -47,7 +47,7 @@ namespace Valve.VR
 
             EVRInputError err = OpenVR.Input.GetAnalogActionData(handle, ref tempActionData, actionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
-                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetAnalogActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> GetAnalogActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
 
             active[inputSource] = tempActionData.bActive;
             activeOrigin[inputSource] = tempActionData.activeOrigin;

--- a/Assets/SteamVR/Input/SteamVR_Action_Skeleton.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Skeleton.cs
@@ -91,7 +91,7 @@ namespace Valve.VR
             EVRInputError err = OpenVR.Input.GetSkeletalActionData(handle, ref tempSkeletonActionData, skeletonActionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
             {
-                Debug.LogError("GetSkeletalActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString()); 
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetSkeletalActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString()); 
                 active[inputSource] = false;
                 return;
             }
@@ -103,7 +103,7 @@ namespace Valve.VR
             {
                 err = OpenVR.Input.GetSkeletalBoneData(handle, skeletalTransformSpace[inputSource], rangeOfMotion[inputSource], tempBoneTransforms, SteamVR_Input_Source.GetHandle(inputSource));
                 if (err != EVRInputError.None)
-                    Debug.LogError("GetSkeletalBoneData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
+                    Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetSkeletalBoneData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
 
                 for (int boneIndex = 0; boneIndex < tempBoneTransforms.Length; boneIndex++)
                 {

--- a/Assets/SteamVR/Input/SteamVR_Action_Skeleton.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Skeleton.cs
@@ -91,7 +91,7 @@ namespace Valve.VR
             EVRInputError err = OpenVR.Input.GetSkeletalActionData(handle, ref tempSkeletonActionData, skeletonActionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
             {
-                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetSkeletalActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString()); 
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> GetSkeletalActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString()); 
                 active[inputSource] = false;
                 return;
             }
@@ -103,7 +103,7 @@ namespace Valve.VR
             {
                 err = OpenVR.Input.GetSkeletalBoneData(handle, skeletalTransformSpace[inputSource], rangeOfMotion[inputSource], tempBoneTransforms, SteamVR_Input_Source.GetHandle(inputSource));
                 if (err != EVRInputError.None)
-                    Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetSkeletalBoneData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
+                    Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> GetSkeletalBoneData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
 
                 for (int boneIndex = 0; boneIndex < tempBoneTransforms.Length; boneIndex++)
                 {

--- a/Assets/SteamVR/Input/SteamVR_Action_Vector2.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Vector2.cs
@@ -47,7 +47,7 @@ namespace Valve.VR
 
             EVRInputError err = OpenVR.Input.GetAnalogActionData(handle, ref tempActionData, actionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
-                Debug.LogError("GetAnalogActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetAnalogActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
 
             active[inputSource] = tempActionData.bActive;
             activeOrigin[inputSource] = tempActionData.activeOrigin;

--- a/Assets/SteamVR/Input/SteamVR_Action_Vector2.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Vector2.cs
@@ -47,7 +47,7 @@ namespace Valve.VR
 
             EVRInputError err = OpenVR.Input.GetAnalogActionData(handle, ref tempActionData, actionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
-                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> GetAnalogActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> GetAnalogActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
 
             active[inputSource] = tempActionData.bActive;
             activeOrigin[inputSource] = tempActionData.activeOrigin;

--- a/Assets/SteamVR/Input/SteamVR_Action_Vector3.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Vector3.cs
@@ -47,7 +47,7 @@ namespace Valve.VR
 
             EVRInputError err = OpenVR.Input.GetAnalogActionData(handle, ref tempActionData, actionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
-                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Vector3 GetAnalogActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> Vector3 GetAnalogActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
 
             active[inputSource] = tempActionData.bActive;
             activeOrigin[inputSource] = tempActionData.activeOrigin;

--- a/Assets/SteamVR/Input/SteamVR_Action_Vector3.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Vector3.cs
@@ -47,7 +47,7 @@ namespace Valve.VR
 
             EVRInputError err = OpenVR.Input.GetAnalogActionData(handle, ref tempActionData, actionData_size, SteamVR_Input_Source.GetHandle(inputSource));
             if (err != EVRInputError.None)
-                Debug.LogError("Vector3 GetAnalogActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Vector3 GetAnalogActionData error (" + fullPath + "): " + err.ToString() + " handle: " + handle.ToString());
 
             active[inputSource] = tempActionData.bActive;
             activeOrigin[inputSource] = tempActionData.activeOrigin;

--- a/Assets/SteamVR/Input/SteamVR_Action_Vibration.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Vibration.cs
@@ -30,7 +30,7 @@ namespace Valve.VR
             //Debug.Log(string.Format("haptic: {5}: {0}, {1}, {2}, {3}, {4}", secondsFromNow, durationSeconds, frequency, amplitude, inputSource, this.GetShortName()));
 
             if (err != EVRInputError.None)
-                Debug.LogError("TriggerHapticVibrationAction (" + fullPath + ") error: " + err.ToString() + " handle: " + handle.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> TriggerHapticVibrationAction (" + fullPath + ") error: " + err.ToString() + " handle: " + handle.ToString());
         }
     }
 }

--- a/Assets/SteamVR/Input/SteamVR_Action_Vibration.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Vibration.cs
@@ -30,7 +30,7 @@ namespace Valve.VR
             //Debug.Log(string.Format("haptic: {5}: {0}, {1}, {2}, {3}, {4}", secondsFromNow, durationSeconds, frequency, amplitude, inputSource, this.GetShortName()));
 
             if (err != EVRInputError.None)
-                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> TriggerHapticVibrationAction (" + fullPath + ") error: " + err.ToString() + " handle: " + handle.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> TriggerHapticVibrationAction (" + fullPath + ") error: " + err.ToString() + " handle: " + handle.ToString());
         }
     }
 }

--- a/Assets/SteamVR/Input/SteamVR_ActivateActionSetOnLoad.cs
+++ b/Assets/SteamVR/Input/SteamVR_ActivateActionSetOnLoad.cs
@@ -23,7 +23,7 @@ namespace Valve.VR
         {
             if (actionSet != null && activateOnStart)
             {
-                //Debug.Log(string.Format("[SteamVR] Activating {0} action set.", actionSet.fullPath));
+                //Debug.Log(string.Format("<b><color=#1b2838>[SteamVR]</color></b> Activating {0} action set.", actionSet.fullPath));
                 actionSet.ActivatePrimary(disableAllOtherActionSets);
             }
         }
@@ -32,7 +32,7 @@ namespace Valve.VR
         {
             if (actionSet != null && deactivateOnDestroy)
             {
-                //Debug.Log(string.Format("[SteamVR] Deactivating {0} action set.", actionSet.fullPath));
+                //Debug.Log(string.Format("<b><color=#1b2838>[SteamVR]</color></b> Deactivating {0} action set.", actionSet.fullPath));
                 actionSet.Deactivate();
             }
         }

--- a/Assets/SteamVR/Input/SteamVR_ActivateActionSetOnLoad.cs
+++ b/Assets/SteamVR/Input/SteamVR_ActivateActionSetOnLoad.cs
@@ -23,7 +23,7 @@ namespace Valve.VR
         {
             if (actionSet != null && activateOnStart)
             {
-                //Debug.Log(string.Format("<b><color=#1b2838>[SteamVR]</color></b> Activating {0} action set.", actionSet.fullPath));
+                //Debug.Log(string.Format("<b><color=#1b2838>[SteamVR Input]</color></b> Activating {0} action set.", actionSet.fullPath));
                 actionSet.ActivatePrimary(disableAllOtherActionSets);
             }
         }
@@ -32,7 +32,7 @@ namespace Valve.VR
         {
             if (actionSet != null && deactivateOnDestroy)
             {
-                //Debug.Log(string.Format("<b><color=#1b2838>[SteamVR]</color></b> Deactivating {0} action set.", actionSet.fullPath));
+                //Debug.Log(string.Format("<b><color=#1b2838>[SteamVR Input]</color></b> Deactivating {0} action set.", actionSet.fullPath));
                 actionSet.Deactivate();
             }
         }

--- a/Assets/SteamVR/Input/SteamVR_DefaultAction.cs
+++ b/Assets/SteamVR/Input/SteamVR_DefaultAction.cs
@@ -134,7 +134,7 @@ namespace Valve.VR
                 {
                     if (action.GetType() != field.FieldType)
                     {
-                        Debug.LogWarning("[SteamVR] Could not assign default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + field.Name
+                        Debug.LogWarning("<b><color=#1b2838>[SteamVR]</color></b> Could not assign default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + field.Name
                             + ". Expected type: " + field.FieldType.Name + ", found action type: " + action.GetType().Name);
                     }
                     else
@@ -156,7 +156,7 @@ namespace Valve.VR
                 if (ShouldAssign(field, onObject))
                 {
                     field.SetValue(onObject, action);
-                    //Debug.Log("[SteamVR] Assigned default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + field.Name
+                    //Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Assigned default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + field.Name
                     //    + ". Expected type: " + field.FieldType.Name + ", found action type: " + action.GetType().Name);   
                 }
             }
@@ -171,7 +171,7 @@ namespace Valve.VR
                 if (ShouldAssign(property, onObject))
                 {
                     property.SetValue(onObject, action, null);
-                    //Debug.Log("[SteamVR] Assigned default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + property.Name
+                    //Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Assigned default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + property.Name
                     //    + ". Expected type: " + property.PropertyType.Name + ", found action type: " + action.GetType().Name);
                 }
             }
@@ -189,7 +189,7 @@ namespace Valve.VR
                 {
                     if (action.GetType() != property.PropertyType)
                     {
-                        Debug.LogWarning("[SteamVR] Could not assign default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + property.Name
+                        Debug.LogWarning("<b><color=#1b2838>[SteamVR]</color></b> Could not assign default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + property.Name
                             + ". Expected type: " + property.PropertyType.Name + ", found action type: " + action.GetType().Name);
                     }
                     else
@@ -198,7 +198,7 @@ namespace Valve.VR
                     }
                 }
                 else
-                    Debug.LogWarning("[SteamVR] Not assigning default because current action is not null. Could not assign default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + property.Name
+                    Debug.LogWarning("<b><color=#1b2838>[SteamVR]</color></b> Not assigning default because current action is not null. Could not assign default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + property.Name
                         + ". Expected type: " + property.PropertyType.Name + ", found action type: " + action.GetType().Name + ". " + ((SteamVR_Action)currentAction).fullPath);
             }
 
@@ -213,10 +213,10 @@ namespace Valve.VR
             var action = SteamVR_Input_References.instance.actionObjects.FirstOrDefault(matchAction => System.Text.RegularExpressions.Regex.IsMatch(matchAction.fullPath, regex, System.Text.RegularExpressions.RegexOptions.IgnoreCase));
 
             if (action == null)
-                Debug.LogWarning("[SteamVR Input] Could not find action matching path: " + regex.Replace("\\", "").Replace(".+", "*"));
-            //else Debug.Log("Looking for: " + regex + ". Found: " + action.fullPath);
+                Debug.LogWarning("<b><color=#1b2838>[SteamVR Input]</color></b> Could not find action matching path: " + regex.Replace("\\", "").Replace(".+", "*"));
+			//else Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Looking for: " + regex + ". Found: " + action.fullPath);
 
-            return action;
+			return action;
         }
 
         private string GetInputSource(MonoBehaviour monoBehaviour, string inputSourceFieldName)

--- a/Assets/SteamVR/Input/SteamVR_DefaultAction.cs
+++ b/Assets/SteamVR/Input/SteamVR_DefaultAction.cs
@@ -134,7 +134,7 @@ namespace Valve.VR
                 {
                     if (action.GetType() != field.FieldType)
                     {
-                        Debug.LogWarning("<b><color=#1b2838>[SteamVR]</color></b> Could not assign default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + field.Name
+                        Debug.LogWarning("<b><color=#1b2838>[SteamVR Input]</color></b> Could not assign default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + field.Name
                             + ". Expected type: " + field.FieldType.Name + ", found action type: " + action.GetType().Name);
                     }
                     else
@@ -156,7 +156,7 @@ namespace Valve.VR
                 if (ShouldAssign(field, onObject))
                 {
                     field.SetValue(onObject, action);
-                    //Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Assigned default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + field.Name
+                    //Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Assigned default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + field.Name
                     //    + ". Expected type: " + field.FieldType.Name + ", found action type: " + action.GetType().Name);   
                 }
             }
@@ -171,7 +171,7 @@ namespace Valve.VR
                 if (ShouldAssign(property, onObject))
                 {
                     property.SetValue(onObject, action, null);
-                    //Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Assigned default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + property.Name
+                    //Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Assigned default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + property.Name
                     //    + ". Expected type: " + property.PropertyType.Name + ", found action type: " + action.GetType().Name);
                 }
             }
@@ -189,7 +189,7 @@ namespace Valve.VR
                 {
                     if (action.GetType() != property.PropertyType)
                     {
-                        Debug.LogWarning("<b><color=#1b2838>[SteamVR]</color></b> Could not assign default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + property.Name
+                        Debug.LogWarning("<b><color=#1b2838>[SteamVR Input]</color></b> Could not assign default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + property.Name
                             + ". Expected type: " + property.PropertyType.Name + ", found action type: " + action.GetType().Name);
                     }
                     else
@@ -198,7 +198,7 @@ namespace Valve.VR
                     }
                 }
                 else
-                    Debug.LogWarning("<b><color=#1b2838>[SteamVR]</color></b> Not assigning default because current action is not null. Could not assign default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + property.Name
+                    Debug.LogWarning("<b><color=#1b2838>[SteamVR Input]</color></b> Not assigning default because current action is not null. Could not assign default action for " + ((MonoBehaviour)onObject).gameObject.name + "::" + ((MonoBehaviour)onObject).name + "::" + property.Name
                         + ". Expected type: " + property.PropertyType.Name + ", found action type: " + action.GetType().Name + ". " + ((SteamVR_Action)currentAction).fullPath);
             }
 
@@ -214,9 +214,9 @@ namespace Valve.VR
 
             if (action == null)
                 Debug.LogWarning("<b><color=#1b2838>[SteamVR Input]</color></b> Could not find action matching path: " + regex.Replace("\\", "").Replace(".+", "*"));
-			//else Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Looking for: " + regex + ". Found: " + action.fullPath);
+            //else Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Looking for: " + regex + ". Found: " + action.fullPath);
 
-			return action;
+            return action;
         }
 
         private string GetInputSource(MonoBehaviour monoBehaviour, string inputSourceFieldName)

--- a/Assets/SteamVR/Input/SteamVR_DefaultActionSet.cs
+++ b/Assets/SteamVR/Input/SteamVR_DefaultActionSet.cs
@@ -61,7 +61,7 @@ namespace Valve.VR
             var actionSet = SteamVR_Input_References.instance.actionSetObjects.FirstOrDefault(matchAction => System.Text.RegularExpressions.Regex.IsMatch(matchAction.fullPath, regex, System.Text.RegularExpressions.RegexOptions.IgnoreCase));
 
             if (actionSet == null)
-                Debug.Log("[SteamVR Input] Could not find action set matching path: " + regex.Replace("\\", "").Replace(".+", "*"));
+                Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Could not find action set matching path: " + regex.Replace("\\", "").Replace(".+", "*"));
 
             return actionSet;
         }

--- a/Assets/SteamVR/Input/SteamVR_Input.cs
+++ b/Assets/SteamVR/Input/SteamVR_Input.cs
@@ -114,17 +114,17 @@ namespace Valve.VR
 
             if (File.Exists(fullPath))
             {
-                Debug.Log("[SteamVR] Loading actions file: " + fullPath);
+                Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Loading actions file: " + fullPath);
 
                 var err = OpenVR.Input.SetActionManifestPath(fullPath);
                 if (err != EVRInputError.None)
-                    Debug.LogError("[SteamVR] Error loading action manifest into SteamVR: " + err.ToString());
+                    Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> Error loading action manifest into SteamVR: " + err.ToString());
                 else
-                    Debug.Log("[SteamVR] Successfully loaded action manifest into SteamVR");
+                    Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Successfully loaded action manifest into SteamVR");
             }
             else
             {
-                Debug.LogError("[SteamVR] Could not find actions file at: " + fullPath);
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> Could not find actions file at: " + fullPath);
             }
         }
 
@@ -162,7 +162,7 @@ namespace Valve.VR
             if (initialized)
                 return;
 
-            Debug.Log("Initializing steamvr input...");
+            Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Initializing steamvr input...");
             initializing = true;
 
             SteamVR_Input_Source.Initialize();
@@ -178,7 +178,7 @@ namespace Valve.VR
                     actionSets[0].ActivatePrimary();
                 else
                 {
-                    Debug.LogError("No action sets.");
+                    Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> No action sets.");
                 }
             }
 
@@ -191,7 +191,7 @@ namespace Valve.VR
             initialized = true;
 
             initializing = false;
-            Debug.Log("Steamvr input initialization complete.");
+            Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Steamvr input initialization complete.");
         }
 
 
@@ -622,7 +622,7 @@ namespace Valve.VR
                 }
                 else
                 {
-                    Debug.Log("Wrong type.");
+                    Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Wrong type.");
                 }
             }
             else
@@ -702,7 +702,7 @@ namespace Valve.VR
             }
             else
             {
-                Debug.LogErrorFormat("[SteamVR] Actions file does not exist in project root: {0}", actionsFilePath);
+                Debug.LogErrorFormat("<b><color=#1b2838>[SteamVR Input]</color></b> Actions file does not exist in project root: {0}", actionsFilePath);
                 return false;
             }
 
@@ -762,7 +762,7 @@ namespace Valve.VR
                 checkingSetup = true;
                 Debug.Break();
 
-                bool open = UnityEditor.EditorUtility.DisplayDialog("[SteamVR]", "It looks like you haven't generated actions for SteamVR Input yet. Would you like to open the SteamVR Input window?", "Yes", "No");
+                bool open = UnityEditor.EditorUtility.DisplayDialog("[SteamVR Input]", "It looks like you haven't generated actions for SteamVR Input yet. Would you like to open the SteamVR Input window?", "Yes", "No");
                 if (open)
                 {
                     UnityEditor.EditorApplication.isPlaying = false;

--- a/Assets/SteamVR/Input/SteamVR_Input_ActionFile.cs
+++ b/Assets/SteamVR/Input/SteamVR_Input_ActionFile.cs
@@ -119,7 +119,7 @@ namespace Valve.VR
                 {
                     if (throwErrors)
                     {
-                        Debug.LogError("[SteamVR] Could not bind binding file specified by the actions.json manifest: " + bindingPath);
+                        Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> Could not bind binding file specified by the actions.json manifest: " + bindingPath);
                     }
                 }
             }
@@ -317,7 +317,7 @@ namespace Valve.VR
             if (dictionary.ContainsKey(languageTagKeyName))
                 language = (string)dictionary[languageTagKeyName];
             else
-                Debug.Log("[SteamVR] Input: Error in actions file, no language_tag in localization array item.");
+                Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Input: Error in actions file, no language_tag in localization array item.");
 
             foreach (KeyValuePair<string, string> item in dictionary)
             {

--- a/Assets/SteamVR/Input/SteamVR_Input_Source.cs
+++ b/Assets/SteamVR/Input/SteamVR_Input_Source.cs
@@ -53,7 +53,7 @@ namespace Valve.VR
                 EVRInputError err = OpenVR.Input.GetInputSourceHandle(path, ref handle);
 
                 if (err != EVRInputError.None)
-                    Debug.LogError("GetInputSourceHandle (" + path + ") error: " + err.ToString());
+                    Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> GetInputSourceHandle (" + path + ") error: " + err.ToString());
 
                 if (enumNames[enumIndex] == SteamVR_Input_Sources.Any.ToString()) //todo: temporary hack
                 {

--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/Hand.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/Hand.cs
@@ -710,7 +710,7 @@ namespace Valve.VR.InteractionSystem
             playerInstance = Player.instance;
             if (!playerInstance)
             {
-                Debug.LogError("No player instance found in Hand Start()");
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> No player instance found in Hand Start()");
             }
 
             // allocate array for colliders
@@ -791,7 +791,7 @@ namespace Valve.VR.InteractionSystem
             int numColliding = Physics.OverlapSphereNonAlloc(hoverPosition, hoverRadius, overlappingColliders, hoverLayerMask.value);
 
             if (numColliding == ColliderArraySize)
-                Debug.LogWarning("This hand is overlapping the max number of colliders: " + ColliderArraySize + ". Some collisions may be missed. Increase ColliderArraySize on Hand.cs");
+                Debug.LogWarning("<b><color=#1b2838>[SteamVR Input]</color></b> This hand is overlapping the max number of colliders: " + ColliderArraySize + ". Some collisions may be missed. Increase ColliderArraySize on Hand.cs");
 
             // DebugVar
             int iActualColliderCount = 0;
@@ -1144,7 +1144,7 @@ namespace Valve.VR.InteractionSystem
         {
             if (spewDebugText)
             {
-                Debug.Log("Hand (" + this.name + "): " + msg);
+                Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Hand (" + this.name + "): " + msg);
             }
         }
 

--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/Interactable.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/Interactable.cs
@@ -75,7 +75,7 @@ namespace Valve.VR.InteractionSystem
             highlightMat = (Material)Resources.Load("SteamVR_HoverHighlight", typeof(Material));
 
             if (highlightMat == null)
-                Debug.LogError("Hover Highlight Material is missing. Please create a material named 'SteamVR_HoverHighlight' and place it in a Resources folder");
+                Debug.LogError("<b><color=#1b2838>[SteamVR Input]</color></b> Hover Highlight Material is missing. Please create a material named 'SteamVR_HoverHighlight' and place it in a Resources folder");
             
         }
 

--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/Throwable.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/Throwable.cs
@@ -136,9 +136,9 @@ namespace Valve.VR.InteractionSystem
         //-------------------------------------------------
         protected virtual void OnAttachedToHand( Hand hand )
 		{
-            //Debug.Log("Pickup: " + hand.GetGrabStarting().ToString());
+			//Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> Pickup: " + hand.GetGrabStarting().ToString());
 
-            hadInterpolation = this.rigidbody.interpolation;
+			hadInterpolation = this.rigidbody.interpolation;
 
             attached = true;
 

--- a/Assets/SteamVR/InteractionSystem/Hints/Scripts/ControllerButtonHints.cs
+++ b/Assets/SteamVR/InteractionSystem/Hints/Scripts/ControllerButtonHints.cs
@@ -162,8 +162,8 @@ namespace Valve.VR.InteractionSystem
             //Only initialize when the render model for the controller hints has been loaded
             if (renderModel == this.renderModel)
             {
-                //Debug.Log("OnRenderModelLoaded: " + this.renderModel.renderModelName);
-                if (initialized)
+				//Debug.Log("<b><color=#1b2838>[SteamVR Input]</color></b> OnRenderModelLoaded: " + this.renderModel.renderModelName);
+				if (initialized)
                 {
                     Destroy(textHintParent.gameObject);
                     componentTransformMap.Clear();
@@ -413,7 +413,7 @@ namespace Valve.VR.InteractionSystem
                 }
                 else
                 {
-                    Debug.LogWarning("Invalid end position for: " + hintInfo.Value.textStartAnchor.name, hintInfo.Value.textStartAnchor.gameObject);
+                    Debug.LogWarning("<b><color=#1b2838>[SteamVR Input]</color></b> Invalid end position for: " + hintInfo.Value.textStartAnchor.name, hintInfo.Value.textStartAnchor.gameObject);
                 }
 				hintInfo.Value.canvasOffset.localRotation = Quaternion.identity;
 			}

--- a/Assets/SteamVR/InteractionSystem/Teleport/Scripts/ChaperoneInfo.cs
+++ b/Assets/SteamVR/InteractionSystem/Teleport/Scripts/ChaperoneInfo.cs
@@ -57,7 +57,7 @@ namespace Valve.VR.InteractionSystem
 			var chaperone = OpenVR.Chaperone;
 			if ( chaperone == null )
 			{
-				Debug.LogWarning( "Failed to get IVRChaperone interface." );
+				Debug.LogWarning( "<b><color=#1b2838>[SteamVR]</color></b> Failed to get IVRChaperone interface." );
 				initialized = true;
 				yield break;
 			}
@@ -73,7 +73,7 @@ namespace Valve.VR.InteractionSystem
 					playAreaSizeZ = pz;
 					roomscale = Mathf.Max( px, pz ) > 1.01f;
 
-					Debug.LogFormat( "ChaperoneInfo initialized. {2} play area {0:0.00}m x {1:0.00}m", px, pz, roomscale ? "Roomscale" : "Standing" );
+					Debug.LogFormat( "<b><color=#1b2838>[SteamVR]</color></b> ChaperoneInfo initialized. {2} play area {0:0.00}m x {1:0.00}m", px, pz, roomscale ? "Roomscale" : "Standing" );
 
 					ChaperoneInfo.Initialized.Send();
 

--- a/Assets/SteamVR/Scripts/SteamVR.cs
+++ b/Assets/SteamVR/Scripts/SteamVR.cs
@@ -109,7 +109,7 @@ namespace Valve.VR
                 var error = EVRInitError.None;
                 if (!SteamVR.usingNativeSupport)
                 {
-                    string errorLog = "[SteamVR] Initialization failed. ";
+                    string errorLog = "<b><color=#1b2838>[SteamVR]</color></b> Initialization failed. ";
 
                     if (XRSettings.enabled == false)
                         errorLog += "VR may be disabled in player settings. Go to player settings in the editor and check the 'Virtual Reality Supported' checkbox'. ";
@@ -174,13 +174,13 @@ namespace Valve.VR
                 case EVRInitError.None:
                     break;
                 case EVRInitError.VendorSpecific_UnableToConnectToOculusRuntime:
-                    Debug.Log("[SteamVR] Initialization Failed!  Make sure device is on, Oculus runtime is installed, and OVRService_*.exe is running.");
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Initialization Failed!  Make sure device is on, Oculus runtime is installed, and OVRService_*.exe is running.");
                     break;
                 case EVRInitError.Init_VRClientDLLNotFound:
-                    Debug.Log("[SteamVR] Drivers not found!  They can be installed via Steam under Library > Tools.  Visit http://steampowered.com to install Steam.");
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Drivers not found!  They can be installed via Steam under Library > Tools.  Visit http://steampowered.com to install Steam.");
                     break;
                 case EVRInitError.Driver_RuntimeOutOfDate:
-                    Debug.Log("[SteamVR] Initialization Failed!  Make sure device's runtime is up to date.");
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Initialization Failed!  Make sure device's runtime is up to date.");
                     break;
                 default:
                     Debug.Log(OpenVR.GetStringForHmdError(error));
@@ -260,14 +260,14 @@ namespace Valve.VR
                 OpenVR.Init(ref error, EVRApplicationType.VRApplication_Utility);
 
                 if (error != EVRInitError.None)
-                    Debug.LogError("[SteamVR] Error during OpenVR Init: " + error.ToString());
+                    Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Error during OpenVR Init: " + error.ToString());
             }
 
             Valve.VR.EVRSettingsError bindingFlagError = Valve.VR.EVRSettingsError.None;
             Valve.VR.OpenVR.Settings.SetBool(Valve.VR.OpenVR.k_pch_SteamVR_Section, Valve.VR.OpenVR.k_pch_SteamVR_DebugInputBinding, true, ref bindingFlagError);
 
             if (bindingFlagError != Valve.VR.EVRSettingsError.None)
-                Debug.LogError("[SteamVR] Error turning on the debug input binding flag in steamvr: " + bindingFlagError.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Error turning on the debug input binding flag in steamvr: " + bindingFlagError.ToString());
 
             if (Application.isPlaying == false)
             {
@@ -276,7 +276,7 @@ namespace Valve.VR
                 SteamVR_Input.IdentifyActionsFile();
             }
 
-            /*
+			/*
             GameObject tempObject = new GameObject("[Temp] [SteamVR Input]");
             SteamVR_Input.Initialize(tempObject);
 
@@ -290,11 +290,11 @@ namespace Valve.VR
 
             if (showBindingsError != EVRInputError.None)
             {
-                Debug.LogError("Error showing bindings ui: " + showBindingsError.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Error showing bindings ui: " + showBindingsError.ToString());
             }
             */
 
-            if (initOpenVR)
+			if (initOpenVR)
                 OpenVR.Shutdown();
 
             Application.OpenURL("http://localhost:8998/dashboard/controllerbinding.html?app=" + SteamVR_Settings.instance.editorAppKey.ToLower()); //todo: update with the actual call
@@ -359,7 +359,7 @@ namespace Valve.VR
                 if (existingFile != null && existingFile.applications != null && existingFile.applications.Count > 0 && 
                     existingFile.applications[0].app_key != SteamVR_Settings.instance.editorAppKey)
                 {
-                    Debug.Log("[SteamVR] Deleting existing VRManifest because it has a different app key.");
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Deleting existing VRManifest because it has a different app key.");
                     FileInfo existingInfo = new FileInfo(fullPath);
                     if (existingInfo.IsReadOnly)
                         existingInfo.IsReadOnly = false;
@@ -401,12 +401,12 @@ namespace Valve.VR
                     }
                     else
                     {
-                        Debug.LogError("[SteamVR] Mismatch in available binding files.");
+                        Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Mismatch in available binding files.");
                     }
                 }
                 else
                 {
-                    Debug.LogError("[SteamVR] Could not load actions file.");
+                    Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Could not load actions file.");
                 }
                 */
 
@@ -432,18 +432,18 @@ namespace Valve.VR
 
                 var addManifestErr = OpenVR.Applications.AddApplicationManifest(manifestPath, true);
                 if (addManifestErr != EVRApplicationError.None)
-                    Debug.LogError("Error adding vr manifest file: " + addManifestErr.ToString());
+                    Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Error adding vr manifest file: " + addManifestErr.ToString());
                 else
-                    Debug.Log("Successfully added vr manifest");
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Successfully added vr manifest");
             }
 
             int processId = System.Diagnostics.Process.GetCurrentProcess().Id;
             var applicationIdentifyErr = OpenVR.Applications.IdentifyApplication((uint)processId, SteamVR_Settings.instance.editorAppKey);
 
             if (applicationIdentifyErr != EVRApplicationError.None)
-                Debug.LogError("Error identifying application: " + applicationIdentifyErr.ToString());
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b>Error identifying application: " + applicationIdentifyErr.ToString());
             else
-                Debug.Log("Successfully identified application");
+                Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Successfully identified application");
         }
 
         #region Event callbacks
@@ -516,7 +516,7 @@ namespace Valve.VR
         private SteamVR()
         {
             hmd = OpenVR.System;
-            Debug.Log("Connected to " + hmd_TrackingSystemName + ":" + hmd_SerialNumber);
+            Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Connected to " + hmd_TrackingSystemName + ":" + hmd_SerialNumber);
 
             compositor = OpenVR.Compositor;
             overlay = OpenVR.Overlay;

--- a/Assets/SteamVR/Scripts/SteamVR_Behaviour.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Behaviour.cs
@@ -136,12 +136,12 @@ namespace Valve.VR
             }
             else
             {
-                Debug.LogError("Tried to async load: " + openVRDeviceName + ". Loaded: " + deviceName);
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Tried to async load: " + openVRDeviceName + ". Loaded: " + deviceName);
                 loadedOpenVRDeviceSuccess = true; //try anyway
             }
         }
 #else
-        private IEnumerator DoInitializeSteamVR(bool forceUnityVRToOpenVR = false)
+		private IEnumerator DoInitializeSteamVR(bool forceUnityVRToOpenVR = false)
         {
             XRSettings.LoadDeviceByName(openVRDeviceName);
             yield return null;

--- a/Assets/SteamVR/Scripts/SteamVR_CameraFlip.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_CameraFlip.cs
@@ -13,7 +13,7 @@ namespace Valve.VR
     {
         void Awake()
         {
-            Debug.Log("SteamVR_CameraFlip is deprecated in Unity 5.4 - REMOVING");
+            Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> SteamVR_CameraFlip is deprecated in Unity 5.4 - REMOVING");
             DestroyImmediate(this);
         }
     }

--- a/Assets/SteamVR/Scripts/SteamVR_CameraMask.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_CameraMask.cs
@@ -13,7 +13,7 @@ namespace Valve.VR
     {
         void Awake()
         {
-            Debug.Log("SteamVR_CameraMask is deprecated in Unity 5.4 - REMOVING");
+            Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> SteamVR_CameraMask is deprecated in Unity 5.4 - REMOVING");
             DestroyImmediate(this);
         }
     }

--- a/Assets/SteamVR/Scripts/SteamVR_LoadLevel.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_LoadLevel.cs
@@ -331,23 +331,23 @@ namespace Valve.VR
 
             if (!string.IsNullOrEmpty(internalProcessPath))
             {
-                Debug.Log("Launching external application...");
+                Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Launching external application...");
                 var applications = OpenVR.Applications;
                 if (applications == null)
                 {
-                    Debug.Log("Failed to get OpenVR.Applications interface!");
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Failed to get OpenVR.Applications interface!");
                 }
                 else
                 {
                     var workingDirectory = Directory.GetCurrentDirectory();
                     var fullPath = Path.Combine(workingDirectory, internalProcessPath);
-                    Debug.Log("LaunchingInternalProcess");
-                    Debug.Log("ExternalAppPath = " + internalProcessPath);
-                    Debug.Log("FullPath = " + fullPath);
-                    Debug.Log("ExternalAppArgs = " + internalProcessArgs);
-                    Debug.Log("WorkingDirectory = " + workingDirectory);
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> LaunchingInternalProcess");
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> ExternalAppPath = " + internalProcessPath);
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> FullPath = " + fullPath);
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> ExternalAppArgs = " + internalProcessArgs);
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> WorkingDirectory = " + workingDirectory);
                     var error = applications.LaunchInternalProcess(fullPath, internalProcessArgs, workingDirectory);
-                    Debug.Log("LaunchInternalProcessError: " + error);
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> LaunchInternalProcessError: " + error);
 #if UNITY_EDITOR
                     UnityEditor.EditorApplication.isPlaying = false;
 #elif !UNITY_METRO

--- a/Assets/SteamVR/Scripts/SteamVR_Menu.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Menu.cs
@@ -236,7 +236,7 @@ namespace Valve.VR
             var texture = overlay.texture as RenderTexture;
             if (texture == null)
             {
-                Debug.LogError("Menu requires overlay texture to be a render texture.");
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Menu requires overlay texture to be a render texture.");
                 return;
             }
 

--- a/Assets/SteamVR/Scripts/SteamVR_PlayArea.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_PlayArea.cs
@@ -47,7 +47,7 @@ namespace Valve.VR
                 var chaperone = OpenVR.Chaperone;
                 bool success = (chaperone != null) && chaperone.GetPlayAreaRect(ref pRect);
                 if (!success)
-                    Debug.LogWarning("Failed to get Calibrated Play Area bounds!  Make sure you have tracking first, and that your space is calibrated.");
+                    Debug.LogWarning("<b><color=#1b2838>[SteamVR]</color></b> Failed to get Calibrated Play Area bounds!  Make sure you have tracking first, and that your space is calibrated.");
 
                 if (initOpenVR)
                     OpenVR.Shutdown();

--- a/Assets/SteamVR/Scripts/SteamVR_RenderModel.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_RenderModel.cs
@@ -96,7 +96,7 @@ namespace Valve.VR
                         _instance = OpenVR.RenderModels;
                         if (_instance == null)
                         {
-                            Debug.LogError("Failed to load IVRRenderModels interface version " + OpenVR.IVRRenderModels_Version);
+                            Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Failed to load IVRRenderModels interface version " + OpenVR.IVRRenderModels_Version);
                             failedLoadInterface = true;
                         }
                     }
@@ -154,7 +154,7 @@ namespace Valve.VR
             var capacity = system.GetStringTrackedDeviceProperty((uint)index, ETrackedDeviceProperty.Prop_RenderModelName_String, null, 0, ref error);
             if (capacity <= 1)
             {
-                Debug.LogError("Failed to get render model name for tracked object " + index);
+                Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Failed to get render model name for tracked object " + index);
                 return;
             }
 
@@ -246,9 +246,9 @@ namespace Valve.VR
                         var pRenderModel = System.IntPtr.Zero;
 
                         var error = renderModels.LoadRenderModel_Async(renderModelNames[renderModelNameIndex], ref pRenderModel);
-                        //Debug.Log("renderModels.LoadRenderModel_Async(" + renderModelNames[renderModelNameIndex] + ": " + error.ToString());
+						//Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> renderModels.LoadRenderModel_Async(" + renderModelNames[renderModelNameIndex] + ": " + error.ToString());
 
-                        if (error == EVRRenderModelError.Loading)
+						if (error == EVRRenderModelError.Loading)
                         {
                             loading = true;
                         }
@@ -264,9 +264,9 @@ namespace Valve.VR
                                 var pDiffuseTexture = System.IntPtr.Zero;
 
                                 error = renderModels.LoadTexture_Async(renderModel.diffuseTextureId, ref pDiffuseTexture);
-                                //Debug.Log("renderModels.LoadRenderModel_Async(" + renderModelNames[renderModelNameIndex] + ": " + error.ToString());
+								//Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> renderModels.LoadRenderModel_Async(" + renderModelNames[renderModelNameIndex] + ": " + error.ToString());
 
-                                if (error == EVRRenderModelError.Loading)
+								if (error == EVRRenderModelError.Loading)
                                 {
                                     loading = true;
                                 }
@@ -306,7 +306,7 @@ namespace Valve.VR
                         return true;
                     }
 
-                    Debug.Log("[" + gameObject.name + "] Render model does not support components, falling back to single mesh.");
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> [" + gameObject.name + "] Render model does not support components, falling back to single mesh.");
                 }
 
                 if (!string.IsNullOrEmpty(renderModelName))
@@ -319,7 +319,7 @@ namespace Valve.VR
                             return false;
 
                         if (verbose)
-                            Debug.Log("Loading render model " + renderModelName);
+                            Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Loading render model " + renderModelName);
 
                         model = LoadRenderModel(renderModels, renderModelName, renderModelName);
                         if (model == null)
@@ -464,7 +464,7 @@ namespace Valve.VR
                 }
                 else
                 {
-                    Debug.Log("Failed to load render model texture for render model " + renderModelName + ". Error: " + error.ToString());
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Failed to load render model texture for render model " + renderModelName + ". Error: " + error.ToString());
                 }
             }
 
@@ -608,7 +608,7 @@ namespace Valve.VR
                 if (model == null || model.mesh == null)
                 {
                     if (verbose)
-                        Debug.Log("Loading render model " + componentRenderModelName);
+                        Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Loading render model " + componentRenderModelName);
 
                     model = LoadRenderModel(renderModels, componentRenderModelName, renderModelName);
                     if (model == null)

--- a/Assets/SteamVR/Scripts/SteamVR_Settings.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Settings.cs
@@ -40,7 +40,7 @@ namespace Valve.VR
                 if (string.IsNullOrEmpty(_instance.editorAppKey))
                 {
                     _instance.editorAppKey = SteamVR.GenerateAppKey();
-                    Debug.Log("[SteamVR] Generated you an editor app key of: " + _instance.editorAppKey + ". This lets the editor tell SteamVR what project this is. Has no effect on builds. This can be changed in Assets/SteamVR/Resources/SteamVR_Settings");
+                    Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Generated you an editor app key of: " + _instance.editorAppKey + ". This lets the editor tell SteamVR what project this is. Has no effect on builds. This can be changed in Assets/SteamVR/Resources/SteamVR_Settings");
 #if UNITY_EDITOR
                     UnityEditor.EditorUtility.SetDirty(_instance);
                     UnityEditor.AssetDatabase.SaveAssets();

--- a/Assets/SteamVR/Scripts/SteamVR_Skybox.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Skybox.cs
@@ -89,11 +89,11 @@ namespace Valve.VR
                 var error = compositor.SetSkyboxOverride(textures);
                 if (error != EVRCompositorError.None)
                 {
-                    Debug.LogError("Failed to set skybox override with error: " + error);
+                    Debug.LogError("<b><color=#1b2838>[SteamVR]</color></b> Failed to set skybox override with error: " + error);
                     if (error == EVRCompositorError.TextureIsOnWrongDevice)
-                        Debug.Log("Set your graphics driver to use the same video card as the headset is plugged into for Unity.");
+                        Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Set your graphics driver to use the same video card as the headset is plugged into for Unity.");
                     else if (error == EVRCompositorError.TextureUsesUnsupportedFormat)
-                        Debug.Log("Ensure skybox textures are not compressed and have no mipmaps.");
+                        Debug.Log("<b><color=#1b2838>[SteamVR]</color></b> Ensure skybox textures are not compressed and have no mipmaps.");
                 }
             }
         }


### PR DESCRIPTION
SteamVR Debug.Log* statements have been amended with `<b><color=#1b2838>[SteamVR]</color></b>` so that they are easier to identify in the Unity Console. Anything under `/Input` or `/InteractionSystem` uses `[SteamVR Input]` instead.

![Example Log](https://user-images.githubusercontent.com/11388300/46326581-c4fe3200-c640-11e8-9056-baa6fabca7f6.PNG)
