### PR TITLE
Remove hand listener on destroy

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/RenderModel.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/RenderModel.cs
@@ -115,6 +115,12 @@ namespace Valve.VR.InteractionSystem
             renderModelLoadedAction.enabled = false;
         }
 
+        protected void OnDestroy()
+        {
+            handSkeleton.skeletonAction.RemoveOnActiveChangeListener(OnSkeletonActiveChange, handSkeleton.inputSource);
+            DestroyHand();
+        }
+
         public virtual void SetInputSource(SteamVR_Input_Sources newInputSource)
         {
             inputSource = newInputSource;


### PR DESCRIPTION
Quick backstory:
Had an issue in a project where each scene has a different SteamVR player. Loading between scenes is done additively and the player from the old scene is deleted just as we transition into the new scene. The issue is that if you start in scene A and press the system button to enter the SteamVR menu then exit the menu back into the game, then transition into scene B, if you then try going into the SteamVR menu it would try running `OnSkeletonActiveChange` on the deleted render model instance. This had the side effect of constantly running `InitializeHand` and spawning a new hand model each frame.

I have solved this by removing the listener for `OnSkeletonActiveChange` when the render model gets destroyed.