### PR TITLE
Item package spawner fixes

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/ItemPackageSpawner.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/ItemPackageSpawner.cs
@@ -224,7 +224,7 @@ namespace Valve.VR.InteractionSystem
                 if (hand.isActive)
 				{
 					ItemPackage currentAttachedItemPackage = GetAttachedItemPackage( hand );
-                    if (currentAttachedItemPackage == itemPackage && hand.IsGrabEnding(currentAttachedItemPackage.gameObject))
+					if (currentAttachedItemPackage == itemPackage && hand.GetGrabStarting() != GrabTypes.None)
 					{
 						TakeBackItem( hand );
 						return; // So that we don't pick up an ItemPackage the same frame that we return it

--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/ItemPackageSpawner.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/ItemPackageSpawner.cs
@@ -166,6 +166,7 @@ namespace Valve.VR.InteractionSystem
 				if ( takeBackItem && !requireTriggerPressToReturn ) // if we want to take back matching items and aren't waiting for a trigger press
 				{
 					TakeBackItem( hand );
+					return;
 				}
 			}
 


### PR DESCRIPTION
There are 2 fixes to the ItemPackageSpawner class in this pull request.

1. Currently if you set requireTriggerPressToTake = false and requireTriggerPressToReturn = false, it will return and pick up the ItemPackage in the same update. There was already logic in place to prevent this same condition from occurring when requireTriggerPressToReturn = true and requireTriggerPresstoTake = true. It seems logical to me that this same prevention measure should be in place when both are equal to false.
2. Currently requireTriggerPressToReturn = true does not work at all. It seems there was a regression in commit bf6014500bdc5eec2fc923b8920c9f2e8b89a9f1 which I believe I have fixed.