### PR TITLE
Highlight holder will be removed with interactable object.

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/Interactable.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/Interactable.cs
@@ -273,6 +273,10 @@ namespace Valve.VR.InteractionSystem
                 attachedToHand.ForceHoverUnlock();
                 attachedToHand.DetachObject(this.gameObject, false);
             }
+
+            if(highlightHolder != null){
+                Destroy(highlightHolder);
+            }
         }
     }
 }


### PR DESCRIPTION
There is fix to Interactable class. Highlight holder will be destroyed in OnDestroy when is not null.