### PR TITLE
Circular Drive is attached to hand similar to Linear Drive

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/CircularDrive.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/CircularDrive.cs
@@ -258,11 +258,9 @@ namespace Valve.VR.InteractionSystem
 		private void HandHoverUpdate( Hand hand )
         {
             GrabTypes startingGrabType = hand.GetGrabStarting();
-            bool isGrabEnding = hand.IsGrabbingWithType(grabbedWithType) == false;
 
-            if (grabbedWithType == GrabTypes.None && startingGrabType != GrabTypes.None)
+            if (interactable.attachedToHand == null && startingGrabType != GrabTypes.None)
             {
-                grabbedWithType = startingGrabType;
                 // Trigger was just pressed
                 lastHandProjected = ComputeToTransformProjected( hand.hoverSphereTransform );
 
@@ -274,30 +272,28 @@ namespace Valve.VR.InteractionSystem
 
 				driving = true;
 
-				ComputeAngle( hand );
-				UpdateAll();
-
+                hand.AttachObject(gameObject, startingGrabType, attachmentFlags);
                 hand.HideGrabHint();
-			}
-            else if (grabbedWithType != GrabTypes.None && isGrabEnding)
-			{
-				// Trigger was just released
-				if ( hoverLock )
-				{
-					hand.HoverUnlock(interactable);
-					handHoverLocked = null;
-				}
-
-                driving = false;
-                grabbedWithType = GrabTypes.None;
             }
-
-            if ( driving && isGrabEnding == false && hand.hoveringInteractable == this.interactable )
-			{
-				ComputeAngle( hand );
-				UpdateAll();
-			}
 		}
+
+        protected virtual void HandAttachedUpdate(Hand hand)
+        {
+            ComputeAngle(hand);
+            UpdateAll();
+
+            if (hand.IsGrabEnding(this.gameObject))
+            {
+                hand.DetachObject(gameObject);
+
+                if (hoverLock)
+                {
+                    hand.HoverUnlock(interactable);
+                    handHoverLocked = null;
+                }
+            }
+        }
+
 
 
 		//-------------------------------------------------

--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/CircularDrive.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/CircularDrive.cs
@@ -73,7 +73,22 @@ namespace Valve.VR.InteractionSystem
 		public TextMesh debugText = null;
 
 		[Tooltip( "The output angle value of the drive in degrees, unlimited will increase or decrease without bound, take the 360 modulus to find number of rotations" )]
-		public float outAngle;
+		[SerializeField]
+        private float outAngle;
+
+		public float OutAngle
+		{
+			get
+			{
+				return outAngle;
+			}
+			set
+			{
+				outAngle = value;
+				UpdateAll();
+			}
+		}
+
 
 		private Quaternion start;
 
@@ -93,7 +108,7 @@ namespace Valve.VR.InteractionSystem
 
 		private bool driving = false;
 
-		// If the drive is limited as is at min/max, angles greater than this are ignored 
+		// If the drive is limited as is at min/max, angles greater than this are ignored
 		private float minMaxAngularThreshold = 1.0f;
 
 		private bool frozen = false;


### PR DESCRIPTION
Circular Drive, Linear Drive and Throwable all allow a player to move an object. Only Circular Drive was not attached to the hand on a grab. This change allows you to use the features of the Interactable script, as "Hide hand on attach" for the Circular Drive too. 

The outAngle of Circular Drive could be updated outside of the class, as it was a public variable. The variable is now private and a property was added to allow you to still change the outAngle, but now it also updates the gameObject. 

This is my first pull request, so I hope I did this right!