### PR TITLE
implement "AllowSidegrade" functionality in Hand.cs

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/Hand.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/Hand.cs
@@ -1484,11 +1484,19 @@ namespace Valve.VR.InteractionSystem
             {
                 if (attachedObjects[attachedObjectIndex].attachedObject == attachedObject)
                 {
-                    return IsGrabbingWithType(attachedObjects[attachedObjectIndex].grabbedWithType) == false;
+                    if ((attachedObjects[attachedObjectIndex].attachmentFlags & AttachmentFlags.AllowSidegrade) != 0)
+                        return IsGrabbing() == false;
+                    else
+                        return IsGrabbingWithType(attachedObjects[attachedObjectIndex].grabbedWithType) == false;
                 }
             }
 
             return false;
+        }
+		
+        public bool IsGrabbing()
+        {
+            return IsGrabbingWithType(GrabTypes.Grip) || IsGrabbingWithType(GrabTypes.Pinch);
         }
 
         public bool IsGrabbingWithType(GrabTypes type)


### PR DESCRIPTION
Hi, maybe I'm mistaken but I found that the "AllowSidegrade" AttachmentFlag isn't actually referenced anywhere in the SteamVR plugin. This PR implements the AllowSidegrade flag in Hand.cs : IsGrabEnding() how I imagine it was intended: if the attachedObject being checked has the AllowSidegrade flag, it'll check if the Hand is grabbing with either grip type. If the object doesn't have the flag, the original logic will apply, and it'll check if the Hand is grabbing with the 'grabbedWithType' of the attachedObject.