### PR TITLE
Fixed runtime-created SteamVR_Behaviour instance not being set to DontDestroyOnLoad.

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR_Behaviour.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Behaviour.cs
@@ -65,7 +65,7 @@ namespace Valve.VR
                     GameObject objectInstance = new GameObject("[SteamVR]");
                     _instance = objectInstance.AddComponent<SteamVR_Behaviour>();
                     _instance.steamvr_render = objectInstance.AddComponent<SteamVR_Render>();
-					behaviourInstance = _instance;
+                    behaviourInstance = _instance;
                 }
                 else
                 {

--- a/Assets/SteamVR/Scripts/SteamVR_Behaviour.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Behaviour.cs
@@ -65,6 +65,7 @@ namespace Valve.VR
                     GameObject objectInstance = new GameObject("[SteamVR]");
                     _instance = objectInstance.AddComponent<SteamVR_Behaviour>();
                     _instance.steamvr_render = objectInstance.AddComponent<SteamVR_Render>();
+					behaviourInstance = _instance;
                 }
                 else
                 {


### PR DESCRIPTION
There was a missing local variable assignment in SteamVR_Behaviour.Initialize() that caused runtime-created SteamVR_Behaviours (the [SteamVR] game object) not being set to DontDestroyOnLoad.
That meant loading a new scene would destroy the game object and input and poses wouldn't update anymore.