### PR TITLE
Handle actionsFilePath having directory components

### DIFF
--- a/Assets/SteamVR/Input/Editor/SteamVR_Input_PostProcessBuild.cs
+++ b/Assets/SteamVR/Input/Editor/SteamVR_Input_PostProcessBuild.cs
@@ -14,7 +14,9 @@ namespace Valve.VR
             SteamVR_Input.InitializeFile();
             
             FileInfo fileInfo = new FileInfo(pathToBuiltProject);
-            string buildPath = fileInfo.Directory.FullName;
+            string buildPath = Path.Combine(
+                    fileInfo.Directory.FullName,
+                    Path.GetDirectoryName(SteamVR_Settings.instance.actionsFilePath));
 
             bool overwrite = EditorPrefs.GetBool(SteamVR_Input_Generator.steamVRInputOverwriteBuildKey);
 

--- a/Assets/SteamVR/Input/SteamVR_Input_ActionFile.cs
+++ b/Assets/SteamVR/Input/SteamVR_Input_ActionFile.cs
@@ -138,6 +138,7 @@ namespace Valve.VR
 
         public void CopyFilesToPath(string toPath, bool overwrite)
         {
+            Directory.CreateDirectory(toPath);
             string[] files = SteamVR_Input.actionFile.GetFilesToCopy();
 
             foreach (string file in files)


### PR DESCRIPTION
If SteamVR_Settings.actionsFilePath has directory components, files
should be copied into that subdirectory of the standalone build.