### PR TITLE
Fixed an issue with Unity throwing "cannot find ın" error in PCs with Turkish default language.

### DIFF
--- a/Assets/SteamVR/Input/SteamVR_Action.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action.cs
@@ -677,7 +677,7 @@ namespace Valve.VR
             int count = directionEndIndex - setEndIndex - 1;
             string direction = fullPath.Substring(setEndIndex + 1, count);
 
-            if (direction == "in")
+            if (direction == "IN".ToLower(CultureInfo.CurrentCulture))
                 return SteamVR_ActionDirections.In;
             else if (direction == "out")
                 return SteamVR_ActionDirections.Out;


### PR DESCRIPTION
Hi,

In computers with zone settings in Turkish (even if the default Windows language is English), lowercase **I** is **ı** and uppercase **i** is **İ**, and when it comes to string comparisons this fails big time.

Therefore, having CultureInfo.CurrentCulture would automatically convert **IN** to **ın** which the path is converted to upon initialization on machines with zone settings set at Turkish.

For default settings, **IN** will be converted to **in** so it continues to display default behavior.

I know the default suggestion is to change zone settings to English US or UK, but the application I'm developing depends on the my local zone settings. Also, there are a lot of Turkish developers out there suffering from this issue. 

Regards. 