### PR TITLE
Fix for copy example input files failing on Linux

### DIFF
--- a/Assets/SteamVR/Input/Editor/SteamVR_CopyExampleInputFiles.cs
+++ b/Assets/SteamVR/Input/Editor/SteamVR_CopyExampleInputFiles.cs
@@ -47,8 +47,7 @@ namespace Valve.VR
                     string[] files = Directory.GetFiles(path, "*.json");
                     foreach (string file in files)
                     {
-                        lastIndex = file.LastIndexOf("\\");
-                        string filename = file.Substring(lastIndex + 1);
+                        string filename = Path.GetFileName(file);
 
                         string newPath = Path.Combine(dataPath, filename);
 


### PR DESCRIPTION
This fixes errors that occur when trying to use the SteamVR Input window for the first time on Linux. Errors occur in the original code where it complains about the copy failing, because it is attempting to copy the file onto itself.

This change removes the expectation of a Windows like file path. I haven't tested it on Windows, just Linux, but it did copy the files over correctly.