### PR TITLE
Fix Unity crash on "Open binding UI" when using as package

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR.cs
+++ b/Assets/SteamVR/Scripts/SteamVR.cs
@@ -543,15 +543,21 @@ namespace Valve.VR
             }
 
             int processId = System.Diagnostics.Process.GetCurrentProcess().Id;
-            EVRApplicationError applicationIdentifyErr = OpenVR.Applications.IdentifyApplication((uint)processId, SteamVR_Settings.instance.editorAppKey);
 
-            if (applicationIdentifyErr != EVRApplicationError.None)
-                Debug.LogError("<b>[SteamVR]</b> Error identifying application: " + applicationIdentifyErr.ToString());
-            else
+            if (!string.IsNullOrEmpty(SteamVR_Settings.instance.editorAppKey)) 
             {
-                if (showLogs)
-                    Debug.Log(string.Format("<b>[SteamVR]</b> Successfully identified process as editor project to SteamVR ({0})", SteamVR_Settings.instance.editorAppKey));
-            }
+                EVRApplicationError applicationIdentifyErr = OpenVR.Applications.IdentifyApplication((uint)processId, SteamVR_Settings.instance.editorAppKey);
+
+                if (applicationIdentifyErr != EVRApplicationError.None) 
+                    Debug.LogError("<b>[SteamVR]</b> Error identifying application: " + applicationIdentifyErr.ToString());
+                else 
+                {
+                    if (showLogs) 
+                        Debug.Log(string.Format("<b>[SteamVR]</b> Successfully identified process as editor project to SteamVR ({0})", SteamVR_Settings.instance.editorAppKey));
+                }
+            } 
+            else 
+                Debug.LogError("<b>[SteamVR]</b> SteamVR_Settings.instance.editorAppKey is NULL, cannot identify application!");
         }
 
         #region Event callbacks

--- a/Assets/SteamVR/Scripts/SteamVR_Settings.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Settings.cs
@@ -97,6 +97,10 @@ namespace Valve.VR
 
 #if UNITY_EDITOR
                     string folderPath = SteamVR.GetResourcesFolderPath(true);
+                    if (!System.IO.Directory.Exists(folderPath)) {
+                        Debug.LogWarning($"<b>[SteamVR]</b> Path '{folderPath}' did not exist; creating ...");
+                        System.IO.Directory.CreateDirectory(folderPath);
+                    }
                     string assetPath = System.IO.Path.Combine(folderPath, "SteamVR_Settings.asset");
 
                     UnityEditor.AssetDatabase.CreateAsset(_instance, assetPath);


### PR DESCRIPTION
When using SteamVR Unity Plugin as a package (by adding a package manifest / package.json to the SteamVR folder and then adding it via Packages/manifest.json), SteamVR_Settings.asset cannot be created and Unity crashes when you click the button "Open binding UI" in the Window "SteamVR Input".

There were two issues causing that crash:

1. SteamVR_Settings could not be created / stored because when using the SteamVR Unity Plugin as package (using Unity Package Manager / UPM), the folder Assets/SteamVR/Resources does not exist.
2. SteamVR_Settings missing caused null to be passed to OpenVR.Applications.IdentifyApplication(...) which results in a Unity crash.

This pull request fixes both issues by creating the folder, if it isn't available, and not calling OpenVR.Applications.IdentifyApplication(...) if SteamVR_Settings.instance.editorAppKey is null.