### PR TITLE
fix: use clearanceCheckMask when checking for hand overlap

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/HandPhysics.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/HandPhysics.cs
@@ -101,7 +101,7 @@ namespace Valve.VR.InteractionSystem
                 if (!collisionsEnabled)
                 {
                     clearanceBuffer[0] = null;
-                    Physics.OverlapSphereNonAlloc(hand.objectAttachmentPoint.position, collisionReenableClearanceRadius, clearanceBuffer);
+                    Physics.OverlapSphereNonAlloc(hand.objectAttachmentPoint.position, collisionReenableClearanceRadius, clearanceBuffer, clearanceCheckMask);
                     // if we don't find anything in the vicinity, reenable collisions!
                     if (clearanceBuffer[0] == null)
                     {


### PR DESCRIPTION
HandPhysics stops working after you release an item.
Note: I had my own colliders around the hand which were overlapping with HandPhysics, and therefore after first pickup, you cannot interact physically with an item anymore. There is clearanceCheckMask that I believe serves the purpose of telling which items this check should ignore.

The `clearanceCheckMask` is defined and can be configured, but is simply not being used when hand releases an object.

This PR uses it in what I believe was intended place.

I can confirm it's working as it solved my bug.