### PR TITLE
Fixed File Path Issues (on 2.4.1b)

### DIFF
--- a/Assets/SteamVR/Input/SteamVR_Input_ActionFile.cs
+++ b/Assets/SteamVR/Input/SteamVR_Input_ActionFile.cs
@@ -140,6 +140,13 @@ namespace Valve.VR
         {
             string[] files = SteamVR_Input.actionFile.GetFilesToCopy();
 
+            DirectoryInfo toPathInfo = new DirectoryInfo(toPath);
+            if (toPathInfo.Exists == false)
+            {
+                Debug.LogWarning("<b>[SteamVR]</b> Creating directory because it did not exist: " + toPathInfo.FullName);
+                toPathInfo.Create();
+            }
+
             foreach (string file in files)
             {
                 FileInfo bindingInfo = new FileInfo(file);


### PR DESCRIPTION
This pull request fixes an issue that occurred when using _Save and generate_ in the _SteamVR Input_ pane (in Unity). All default bindings were removed because the binding files were not found due to the script looking for just the file name (instead of using the full path). Currently, a warning is logged when `GetBindingFileObject(path)` / `CheckPath(path)` is called with an incomplete path but the path is automatically corrected (see method `CheckPath(string path)` in `SteamVR_Input_ActionManifest_Manager`). That warning could probably be removed - I kept it in for easier testing.

This pull request also fixes a build-time issue that occurred when actions.json was not in the project root folder and its folder had not been previously created in the build target folder. This folder is now automatically created if it not exists.