### PR TITLE
Fixed SteamVR not initialized when only using SteamVR_Behaviour_Skeleton

### DIFF
--- a/Assets/SteamVR/Input/SteamVR_Behaviour_Skeleton.cs
+++ b/Assets/SteamVR/Input/SteamVR_Behaviour_Skeleton.cs
@@ -343,6 +343,8 @@ namespace Valve.VR
 
         protected virtual void OnEnable()
         {
+            SteamVR.Initialize();
+
             CheckSkeletonAction();
             SteamVR_Input.onSkeletonsUpdated += SteamVR_Input_OnSkeletonsUpdated;
 


### PR DESCRIPTION
When I was only using `SteamVR_Behaviour_Skeleton` scripts to track hands in my scene, the skeleton tracking and pose tracking were not working because SteamVR was not correctly initialized.

I checked the script in `SteamVR_Behaviour_Pose` and it would initialize SteamVR when it was enabled. So I added the same fix to the skeleton script in case only `SteamVR_Behaviour_Skeleton` is used in the scene instead of `SteamVR_Behaviour_Pose`.