### PR TITLE
Use AssetDatabase over Directory to resolve partial input manifests

### DIFF
--- a/Assets/SteamVR/Input/Editor/SteamVR_Input_ActionManifest_Manager.cs
+++ b/Assets/SteamVR/Input/Editor/SteamVR_Input_ActionManifest_Manager.cs
@@ -811,7 +811,10 @@ namespace Valve.VR
 
         public static Dictionary<string, List<SteamVR_PartialInputBindings>> ScanForPartials()
         {
-            string[] partialManifestPaths = Directory.GetFiles(Application.dataPath, partialManifestFilename, SearchOption.AllDirectories);
+            string[] partialManifestPaths = AssetDatabase.FindAssets(System.IO.Path.GetFileNameWithoutExtension(partialManifestFilename))
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .Where(path => path.EndsWith(partialManifestFilename))
+                .ToArray();
             Dictionary<string, List<SteamVR_PartialInputBindings>> partialBindings = new Dictionary<string, List<SteamVR_PartialInputBindings>>();
 
             for (int partialIndex = 0; partialIndex < partialManifestPaths.Length; partialIndex++)


### PR DESCRIPTION
This allows packages using PackageManager to provide bindings.