### PR TITLE
Added Vive tracker roles for elbows and knees

### DIFF
--- a/Assets/SteamVR/Input/SteamVR_Input_Sources.cs
+++ b/Assets/SteamVR/Input/SteamVR_Input_Sources.cs
@@ -51,6 +51,18 @@ namespace Valve.VR
 
         [Description("/user/treadmill")]
         Treadmill,
+        
+        [Description("/user/knee/left")]
+        LeftKnee,
+
+        [Description("/user/knee/right")]
+        RightKnee,
+
+        [Description("/user/elbow/left")]
+        LeftElbow,
+
+        [Description("/user/elbow/right")]
+        RightElbow,
     }
 }
 


### PR DESCRIPTION
This requires SteamVR 1.10.9 (currently beta), and you need to add the bindings as well, of course (as usual with trackers).