### PR TITLE
fix: don't set worse fixedDeltaTime

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR_Render.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Render.cs
@@ -461,7 +461,12 @@ namespace Valve.VR
                     //timing.m_nSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf(typeof(Compositor_FrameTiming));
                     //vr.compositor.GetFrameTiming(ref timing, 0);
 
-                    Time.fixedDeltaTime = Time.timeScale / vr.hmd_DisplayFrequency;
+                    float dynamicTime = Time.timeScale / vr.hmd_DisplayFrequency;
+                    if (Time.fixedDeltaTime > dynamicTime)
+                    {
+                        Debug.Log("SteamVR: Forcing Fixed Delta Time to " + dynamicTime + " to match HMD.");
+                        Time.fixedDeltaTime = dynamicTime;
+                    }
                 }
             }
         }


### PR DESCRIPTION
SteamVR sets the fixedDeltaTime to a worse value than may be manually set in the Time settings in Unity due to HMD refresh being slower than the time specified. If the fixedDeltaTime set by SteamVR would be set to a worse value than is currently chosen, then leave it where it is.