### PR TITLE
Added "RemoveAllListeners" For Boolean/Vector2/Single Actions

### DIFF
--- a/Assets/SteamVR/Input/SteamVR_Action_Boolean.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Boolean.cs
@@ -213,6 +213,14 @@ namespace Valve.VR
             sourceMap[inputSource].onStateUp -= functionToStopCalling;
         }
 
+        /// <summary>
+        /// Remove all listeners registered in the source, useful for Dispose pattern
+        /// </summary>
+        public void RemoveAllListeners(SteamVR_Input_Sources input_Sources)
+		{
+			sourceMap[input_Sources].RemoveAllListeners();
+		}
+
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {
         }
@@ -339,6 +347,35 @@ namespace Valve.VR
                 actionData_size = (uint)Marshal.SizeOf(typeof(InputDigitalActionData_t));
 
         }
+
+        /// <summary>
+        /// Remove all listeners, useful for Dispose pattern
+        /// </summary>
+        public void RemoveAllListeners()
+		{
+			Delegate[] delegates = onStateDown?.GetInvocationList();
+			if (delegates != null)
+			{
+				foreach (Delegate d in onStateDown.GetInvocationList())
+					onStateDown -= (SteamVR_Action_Boolean.StateDownHandler)d;
+			}
+
+			delegates = onStateUp?.GetInvocationList();
+			if (delegates != null)
+			{
+				foreach (Delegate d in onStateUp.GetInvocationList())
+					onStateUp -= (SteamVR_Action_Boolean.StateUpHandler)d;
+			}
+
+			delegates = onState?.GetInvocationList();
+			if (delegates != null)
+			{
+				foreach (Delegate d in onState.GetInvocationList())
+				{
+					onState -= (SteamVR_Action_Boolean.StateHandler)d;
+				}
+			}
+		}
 
         /// <summary><strong>[Should not be called by user code]</strong>
         /// Updates the data for this action and this input source. Sends related events.

--- a/Assets/SteamVR/Input/SteamVR_Action_Single.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Single.cs
@@ -171,9 +171,9 @@ namespace Valve.VR
         /// Removes all listeners, useful for dispose pattern
         /// </summary>
         public void RemoveAllListeners(SteamVR_Input_Sources inputSource)
-		{
-			sourceMap[inputSource].RemoveAllListeners();
-		}
+	{
+		sourceMap[inputSource].RemoveAllListeners();
+	}
 
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {
@@ -295,22 +295,22 @@ namespace Valve.VR
         /// Removes all listeners, useful for dispose pattern
         /// </summary>
         public void RemoveAllListeners()
-		{
-			Delegate[] delegates = onAxis?.GetInvocationList();
-			if (delegates != null)
-				foreach (Delegate d in onAxis.GetInvocationList())
-					onAxis -= (SteamVR_Action_Single.AxisHandler)d;
+	{
+		Delegate[] delegates = onAxis?.GetInvocationList();
+		if (delegates != null)
+			foreach (Delegate d in onAxis.GetInvocationList())
+				onAxis -= (SteamVR_Action_Single.AxisHandler)d;
 
-			delegates = onUpdate?.GetInvocationList();
-			if (delegates != null)
-				foreach (Delegate d in onUpdate.GetInvocationList())
-				onUpdate -= (SteamVR_Action_Single.UpdateHandler)d;
-			
-			delegates = onChange?.GetInvocationList();
-			if (delegates != null)
-				foreach (Delegate d in onChange.GetInvocationList())
-				onChange -= (SteamVR_Action_Single.ChangeHandler)d;
-		}
+		delegates = onUpdate?.GetInvocationList();
+		if (delegates != null)
+			foreach (Delegate d in onUpdate.GetInvocationList())
+			onUpdate -= (SteamVR_Action_Single.UpdateHandler)d;
+
+		delegates = onChange?.GetInvocationList();
+		if (delegates != null)
+			foreach (Delegate d in onChange.GetInvocationList())
+			onChange -= (SteamVR_Action_Single.ChangeHandler)d;
+	}
 
         /// <summary><strong>[Should not be called by user code]</strong>
         /// Updates the data for this action and this input source. Sends related events.

--- a/Assets/SteamVR/Input/SteamVR_Action_Single.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Single.cs
@@ -167,6 +167,14 @@ namespace Valve.VR
             sourceMap[inputSource].onAxis -= functionToStopCalling;
         }
 
+        /// <summary>
+        /// Removes all listeners, useful for dispose pattern
+        /// </summary>
+        public void RemoveAllListeners(SteamVR_Input_Sources inputSource)
+		{
+			sourceMap[inputSource].RemoveAllListeners();
+		}
+
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {
         }
@@ -282,6 +290,27 @@ namespace Valve.VR
             if (actionData_size == 0)
                 actionData_size = (uint)Marshal.SizeOf(typeof(InputAnalogActionData_t));
         }
+        
+        /// <summary>
+        /// Removes all listeners, useful for dispose pattern
+        /// </summary>
+        public void RemoveAllListeners()
+		{
+			Delegate[] delegates = onAxis?.GetInvocationList();
+			if (delegates != null)
+				foreach (Delegate d in onAxis.GetInvocationList())
+					onAxis -= (SteamVR_Action_Single.AxisHandler)d;
+
+			delegates = onUpdate?.GetInvocationList();
+			if (delegates != null)
+				foreach (Delegate d in onUpdate.GetInvocationList())
+				onUpdate -= (SteamVR_Action_Single.UpdateHandler)d;
+			
+			delegates = onChange?.GetInvocationList();
+			if (delegates != null)
+				foreach (Delegate d in onChange.GetInvocationList())
+				onChange -= (SteamVR_Action_Single.ChangeHandler)d;
+		}
 
         /// <summary><strong>[Should not be called by user code]</strong>
         /// Updates the data for this action and this input source. Sends related events.

--- a/Assets/SteamVR/Input/SteamVR_Action_Vector2.cs
+++ b/Assets/SteamVR/Input/SteamVR_Action_Vector2.cs
@@ -170,6 +170,14 @@ namespace Valve.VR
             sourceMap[inputSource].onAxis -= functionToStopCalling;
         }
 
+        /// <summary>
+        /// Removes all listeners, useful for dispose pattern
+        /// </summary>
+        public void RemoveAllListeners(SteamVR_Input_Sources input_Sources)
+		{
+			sourceMap[input_Sources].RemoveAllListeners();
+		}
+
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {
         }
@@ -288,6 +296,27 @@ namespace Valve.VR
             if (actionData_size == 0)
                 actionData_size = (uint)Marshal.SizeOf(typeof(InputAnalogActionData_t));
         }
+
+        /// <summary>
+        /// Removes all listeners, useful for dispose pattern
+        /// </summary>
+        public void RemoveAllListeners()
+		{
+			Delegate[] delegates = onAxis?.GetInvocationList();
+			if (delegates != null)
+				foreach (Delegate d in onAxis.GetInvocationList())
+					onAxis -= (SteamVR_Action_Vector2.AxisHandler)d;
+
+			delegates = onUpdate?.GetInvocationList();
+			if (delegates != null)
+				foreach (Delegate d in onUpdate.GetInvocationList())
+					onUpdate -= (SteamVR_Action_Vector2.UpdateHandler)d;
+
+			delegates = onChange?.GetInvocationList();
+			if (delegates != null)
+				foreach (Delegate d in onChange.GetInvocationList())
+					onChange -= (SteamVR_Action_Vector2.ChangeHandler)d;
+		}
 
         /// <summary><strong>[Should not be called by user code]</strong>
         /// Updates the data for this action and this input source. Sends related events.


### PR DESCRIPTION
Due to the lack of availability for dispose all event from an action I needed to create a way to be able to reset that action
so I created the feature to remove all listeners wich is really useful for Dispose pattern
I'm using this right now to create a shared structure for alternate in using SteamVR and unity new input system without code change requirements