### PR TITLE
Fix for build in v2.7.0b

### DIFF
--- a/Assets/SteamVR/Input/Plugins/JSON.NET/Valve.Newtonsoft.Json.dll.meta
+++ b/Assets/SteamVR/Input/Plugins/JSON.NET/Valve.Newtonsoft.Json.dll.meta
@@ -8,45 +8,13 @@ PluginImporter:
   executionOrder: {}
   isPreloaded: 0
   platformData:
-    '':
+    Any:
       enabled: 1
       settings: {}
     Editor:
-      enabled: 1
+      enabled: 0
       settings:
         DefaultValueInitialized: true
-    Linux:
-      enabled: 0
-      settings:
-        CPU: x86
-    Linux64:
-      enabled: 0
-      settings:
-        CPU: x86_64
-    LinuxUniversal:
-      enabled: 0
-      settings:
-        CPU: AnyCPU
-    OSXIntel:
-      enabled: 0
-      settings:
-        CPU: AnyCPU
-    OSXIntel64:
-      enabled: 0
-      settings:
-        CPU: AnyCPU
-    OSXUniversal:
-      enabled: 0
-      settings:
-        CPU: AnyCPU
-    Win:
-      enabled: 0
-      settings:
-        CPU: AnyCPU
-    Win64:
-      enabled: 0
-      settings:
-        CPU: AnyCPU
     WindowsStoreApps:
       enabled: 0
       settings:

--- a/Assets/SteamVR/Scripts/SteamVR_Settings.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Settings.cs
@@ -121,8 +121,10 @@ namespace Valve.VR
 
         public static void Save()
         {
+#if UNITY_EDITOR
             UnityEditor.EditorUtility.SetDirty(instance);
             UnityEditor.AssetDatabase.SaveAssets();
+#endif
         }
 
         private const string defaultSettingsAssetName = "SteamVR_Settings";


### PR DESCRIPTION
#879
This is a fix for v2.7.0b.

- SteamVR_Input requires Valve.Newtonsoft.Json.dll
- Exclude UnityEditor from Runtime