### PR TITLE
Added fix for deep copy hands bones arrays initialization

### DIFF
--- a/Assets/SteamVR/Input/Editor/SteamVR_Skeleton_PoserEditor.cs
+++ b/Assets/SteamVR/Input/Editor/SteamVR_Skeleton_PoserEditor.cs
@@ -393,6 +393,8 @@ namespace Valve.VR
 
             dest.rightHand.position = source.rightHand.position;
             dest.rightHand.rotation = source.rightHand.rotation;
+            dest.rightHand.bonePositions = new Vector3[boneNum];
+            dest.rightHand.boneRotations = new Quaternion[boneNum];
             for (int boneIndex = 0; boneIndex < boneNum; boneIndex++)
             {
                 dest.rightHand.bonePositions[boneIndex] = source.rightHand.bonePositions[boneIndex];
@@ -409,6 +411,8 @@ namespace Valve.VR
 
             dest.leftHand.position = source.leftHand.position;
             dest.leftHand.rotation = source.leftHand.rotation;
+            dest.leftHand.bonePositions = new Vector3[boneNum];
+            dest.leftHand.boneRotations = new Quaternion[boneNum];
             for (int boneIndex = 0; boneIndex < boneNum; boneIndex++)
             {
                 dest.leftHand.bonePositions[boneIndex] = source.leftHand.bonePositions[boneIndex];


### PR DESCRIPTION
Just added an array initialization for both hands bones positions and rotations.
This fixes my issue in #881 which I was also getting an array out of index error.