### PR TITLE
Add teleportation events

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Teleport/Scripts/Teleport.cs
+++ b/Assets/SteamVR/InteractionSystem/Teleport/Scripts/Teleport.cs
@@ -7,6 +7,7 @@
 using UnityEngine;
 using UnityEngine.Events;
 using System.Collections;
+using UnityEngine.Events;
 
 namespace Valve.VR.InteractionSystem
 {
@@ -64,6 +65,8 @@ namespace Valve.VR.InteractionSystem
 		public Transform offsetReticleTransform;
 		public MeshRenderer floorDebugSphere;
 		public LineRenderer floorDebugLine;
+
+		public UnityEvent onTeleportSucceeded;	// Adds an event hook to the Teleporting (prefab) to hook in events after each teleport action.  
 
 		private LineRenderer pointerLineRenderer;
 		private GameObject teleportPointerObject;
@@ -906,6 +909,9 @@ namespace Valve.VR.InteractionSystem
 				teleportingToMarker.TeleportPlayer( pointedAtPosition );
 			}
 
+ 			onTeleportSucceeded.Invoke();                       // Invoke the event attached to the global teleporting object
+            		teleportingToMarker.onTeleportToHere.Invoke();      // Invoke the event attached to the teleporting object (teleporting point, teleporting area)
+	    
 			Teleport.Player.Send( pointedAtTeleportMarker );
 		}
 

--- a/Assets/SteamVR/InteractionSystem/Teleport/Scripts/TeleportMarkerBase.cs
+++ b/Assets/SteamVR/InteractionSystem/Teleport/Scripts/TeleportMarkerBase.cs
@@ -5,6 +5,7 @@
 //=============================================================================
 
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace Valve.VR.InteractionSystem
 {
@@ -13,6 +14,8 @@ namespace Valve.VR.InteractionSystem
 	{
 		public bool locked = false;
 		public bool markerActive = true;
+		
+		public UnityEvent onTeleportToHere;
 
 		//-------------------------------------------------
 		public virtual bool showReticle


### PR DESCRIPTION
Added a couple of lines to the Teleportation code to assign and invoke Unity Events when teleporting:
- One event is added to the Teleport.cs (teleporting prefab) to allow you to fire an event every time a teleport action succeeds.
- One event is added to the TeleportMarkerBase to allow you to fire an event when you teleport to a TeleportPoint (or Area).
This can be useful for turn based games, triggering actions when you teleport to a specific point or hook-in code for dynamically adding teleport points on Unity terrain.