### PR TITLE
 Teleport.cs: Check for existence of controllers before accessing them

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Teleport/Scripts/Teleport.cs
+++ b/Assets/SteamVR/InteractionSystem/Teleport/Scripts/Teleport.cs
@@ -900,7 +900,7 @@ namespace Valve.VR.InteractionSystem
 					player.leftHand.ResetAttachedTransform(player.leftHand.currentAttachedObjectInfo.Value);
 				if (player.rightHand != null && player.rightHand.currentAttachedObjectInfo.HasValue)
 					player.rightHand.ResetAttachedTransform(player.rightHand.currentAttachedObjectInfo.Value);
-            }
+			}
 			else
 			{
 				teleportingToMarker.TeleportPlayer( pointedAtPosition );

--- a/Assets/SteamVR/InteractionSystem/Teleport/Scripts/Teleport.cs
+++ b/Assets/SteamVR/InteractionSystem/Teleport/Scripts/Teleport.cs
@@ -797,7 +797,7 @@ namespace Valve.VR.InteractionSystem
 		//-------------------------------------------------
 		private void PlayPointerHaptic( bool validLocation )
 		{
-			if ( pointerHand != null )
+			if ( pointerHand != null && pointerHand.noSteamVRFallbackCamera == null )
 			{
 				if ( validLocation )
 				{
@@ -895,11 +895,11 @@ namespace Valve.VR.InteractionSystem
 			{
 				Vector3 playerFeetOffset = player.trackingOriginTransform.position - player.feetPositionGuess;
 				player.trackingOriginTransform.position = teleportPosition + playerFeetOffset;
-
-                if (player.leftHand.currentAttachedObjectInfo.HasValue)
-                    player.leftHand.ResetAttachedTransform(player.leftHand.currentAttachedObjectInfo.Value);
-                if (player.rightHand.currentAttachedObjectInfo.HasValue)
-                    player.rightHand.ResetAttachedTransform(player.rightHand.currentAttachedObjectInfo.Value);
+				
+				if (player.leftHand != null && player.leftHand.currentAttachedObjectInfo.HasValue)
+					player.leftHand.ResetAttachedTransform(player.leftHand.currentAttachedObjectInfo.Value);
+				if (player.rightHand != null && player.rightHand.currentAttachedObjectInfo.HasValue)
+					player.rightHand.ResetAttachedTransform(player.rightHand.currentAttachedObjectInfo.Value);
             }
 			else
 			{


### PR DESCRIPTION
When trying to work on a project without an HMD with controllers, the
project defaults to 2D Debug mode. However, since the code expects the
controllers to exist, it's not able to get past trying to execute haptic
feedback which results in teleporting to fail in 2D Debug mode. These
changes make sure that the script check for controller existence before
trying to access them.

This fixes issue #483 