### PR TITLE
Updated SteamVR_Behaviour to better honor SteamVR_Settings

### DIFF
--- a/Assets/SteamVR/Scripts/SteamVR_Behaviour.cs
+++ b/Assets/SteamVR/Scripts/SteamVR_Behaviour.cs
@@ -33,7 +33,7 @@ namespace Valve.VR
             }
         }
 
-        public bool initializeSteamVROnAwake = true;
+        public bool initializeSteamVROnAwake = SteamVR_Settings.instance.autoEnableVR;
 
         public bool doNotDestroy = true;
 


### PR DESCRIPTION
This bug caused steamvr to initialize on game load regardless of whether the auto start was disabled in settings, making it difficult to develop a desktop mode of the project