### PR TITLE
Fixed issue where hands would not clear

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/HandPhysics.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/HandPhysics.cs
@@ -101,7 +101,7 @@ namespace Valve.VR.InteractionSystem
                 if (!collisionsEnabled)
                 {
                     clearanceBuffer[0] = null;
-                    Physics.OverlapSphereNonAlloc(hand.objectAttachmentPoint.position, collisionReenableClearanceRadius, clearanceBuffer);
+                    Physics.OverlapSphereNonAlloc(hand.objectAttachmentPoint.position, collisionReenableClearanceRadius, clearanceBuffer, clearanceCheckMask);
                     // if we don't find anything in the vicinity, reenable collisions!
                     if (clearanceBuffer[0] == null)
                     {


### PR DESCRIPTION
There was a bug where hands would never clear an object after picking it up. This was due to clearanceCheckMask not being used in UpdateHand() as a layermask.