### PR TITLE
Fix SteamVR_Settings being overwritten during asset import

### DIFF
--- a/Assets/SteamVR/Input/Editor/SteamVR_CopyExampleInputFiles.cs
+++ b/Assets/SteamVR/Input/Editor/SteamVR_CopyExampleInputFiles.cs
@@ -17,6 +17,13 @@ namespace Valve.VR
         [UnityEditor.Callbacks.DidReloadScripts]
         private static void OnReloadScripts()
         {
+            //Delay method calls as SteamVR_Settings.instance cannot be accessed from 'DidReloadScripts'
+            EditorApplication.update += Update;
+        }
+
+        private static void Update()
+        {
+            EditorApplication.update -= Update;
             SteamVR_Input.CheckOldLocation();
             CopyFiles();
         }


### PR DESCRIPTION
SteamVR_Settings are currently overwritten on each asset (re)import as mentioned in #949.

Calling Resources.Load during asset import always returns null.
SteamVR_Settings.instance is using Resources.Load to load existing settings.
SteamVR_CopyExampleInputFiles is calling SteamVR_Settings.instance from DidReloadScripts callback which is first called during asset import and returns null.
This leads to the SteamVR_Settings asset getting overwritten every time the project is (re)imported as mentioned in #949.

This PR is delaying the call to SteamVR_Settings.instance in SteamVR_CopyExampleInputFiles that happens directly during DidReloadScripts till the editor update loop where it is safe to execute Resources.Load.

Fixes #949