### PR TITLE
Initialize hideHighlight in Interactable.cs

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/Interactable.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/Interactable.cs
@@ -67,7 +67,7 @@ namespace Valve.VR.InteractionSystem
         protected SkinnedMeshRenderer[] existingSkinnedRenderers;
         protected static Material highlightMat;
         [Tooltip("An array of child gameObjects to not render a highlight for. Things like transparent parts, vfx, etc.")]
-        public GameObject[] hideHighlight;
+        public GameObject[] hideHighlight = new GameObject[]{};
 
         [Tooltip("Higher is better")]
         public int hoverPriority = 0;


### PR DESCRIPTION
Fixes issue where creating Interactables at runtime by using AddComponent<Valve.VR.InteractionSystem.Throwable>() on a GameObject would throw null reference exception due to hideHighlight not being initialized, preventing itself and its children from showing highlighting.