### PR TITLE
Add a "Set on fire" button to fire source

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Longbow/Scripts/FireSource.cs
+++ b/Assets/SteamVR/InteractionSystem/Longbow/Scripts/FireSource.cs
@@ -69,7 +69,7 @@ namespace Valve.VR.InteractionSystem
 
 
 		//-------------------------------------------------
-		private void FireExposure()
+		public void FireExposure()
 		{
 			if ( fireObject == null )
 			{

--- a/Assets/SteamVR/InteractionSystem/Longbow/Scripts/FireSourceButton.cs
+++ b/Assets/SteamVR/InteractionSystem/Longbow/Scripts/FireSourceButton.cs
@@ -1,0 +1,18 @@
+using UnityEditor;
+using UnityEngine;
+using Valve.VR.InteractionSystem;
+
+[CustomEditor(typeof(FireSource))]
+public class FireSourceButton : Editor
+{
+    public override void OnInspectorGUI()
+    {
+        DrawDefaultInspector();
+
+        FireSource fire = (FireSource)target;
+        if (GUILayout.Button("Set on fire"))
+        {
+            fire.FireExposure();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a button to the "Fire source" script (from InteractionSystem/Longbow) to set the component on fire without a nearby fire source.

I found this very useful when testing my game, and I think it could be a good addition to the repo!

----

The usage of a button requires a second script, it can't be done from the same script. Please tell me if I should change the namespace or something else. Also worth noting I had to make the FireExposure method public.