### PR TITLE
Fixed #593: Physics hands jitter to catch up with controllers

### DIFF
--- a/Assets/SteamVR/InteractionSystem/Core/Scripts/HandCollider.cs
+++ b/Assets/SteamVR/InteractionSystem/Core/Scripts/HandCollider.cs
@@ -280,5 +280,9 @@ namespace Valve.VR.InteractionSystem
             }
         }
 
+        private void OnCollisionStay()
+        {
+            hand.OnHandColliderStay();
+        }
     }
 }


### PR DESCRIPTION
A fix to prevent hand jitter while moving the player at high speeds, while maintaining proper physics collisions with the environment. This fix only affects empty hands. If a held object overrides the hand's position using physics (e.g. Throwable script with VelocityMovement flag), it probably still suffers from the issue.

This fix counts the number of physics updates since the hand has last collided with an object. 
- If the hand hasn't collided with another object for a certain number of physics updates, the render model is teleported to the controller's position every render update. The collider is still simulated as normal.
- Otherwise, the render model aligns itself with the hand collider (as was happening continuously before this fix).